### PR TITLE
add section before publishing branch telling developer to merge first

### DIFF
--- a/documentation/docs/Developer-information/Contributing-to-repository/Create-pull-request.md
+++ b/documentation/docs/Developer-information/Contributing-to-repository/Create-pull-request.md
@@ -14,7 +14,20 @@ Now that you have finished resolving the issue, it is time to create a pull requ
 
 ## Pushing to the remote repository
 
-To begin, run this command in the terminal:
+To begin, run these commands in the terminal:
+
+```bash
+# Get the latest changes to the repository
+git fetch origin master
+
+# Merge these changes into your branch
+git checkout <your-branch-name>
+git merge origin/<branch> # Where <branch> is the one you are working off of
+```
+
+The reason we do this is to ensure that merge conflicts can be adressed before a pull request is made. Please visit [this page](/Developer-information/merge-conflicts.md) for a thorough explanation and example of a merge conflict. If you are working with files no one else is touching, the chances of a merge conflict will be low, but this is still a good habit to get into.
+
+Once any merge conflicts that arise from the above have been resolved, you can publish your branch (push your branch to GitHub) with the following command:
 
 ```bash
 # Push your changes to the remote repository
@@ -22,7 +35,7 @@ git push origin <your-branch-name>
 ```
 
 :::warning[multiple people working on the same branch]
-If you are working on the same branch with other people and the branch has already been published (pushed for the first time) to the online repository, please run the following instead:
+If you are working on the same branch with other people and the branch has already been published (pushed for the first time), please run the following periodically through the development process:
 
 ```bash
 # Pull the latest changes from the remote repository

--- a/documentation/docs/Developer-information/Contributing-to-repository/Create-pull-request.md
+++ b/documentation/docs/Developer-information/Contributing-to-repository/Create-pull-request.md
@@ -18,7 +18,7 @@ To begin, run these commands in the terminal:
 
 ```bash
 # Get the latest changes to the repository
-git fetch origin master
+git fetch
 
 # Merge these changes into your branch
 git checkout <your-branch-name>


### PR DESCRIPTION
# Description

This pull request will add a section explaining why we should be merging the branch you are working off of before making a pull request. The page concerning pull request formation now asks the developer that they use `git fetch` and subsequently merges their branch with the online version of the branch they are working off of. 

Doing this will help catch a lot of merge conflicts before they are pushed to GitHub. Obviously merge conflicts still need to be fixed locally (for which there is a page redirection to the merge conflict example), but this is still a good habit to get into.

## Issue ticket number

This pull request is to address issue: #57.

## Type of pull request

- [ ] Bug fix
- [ ] New feature/enhancement
- [ ] Code refactor
- [x] Documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code to check that it is functional
- [ ] I have used linters to check for common sources of errors
- [ ] I have implemented fail safes in my code to account for edge cases
- [x] I have made the corresponding changes to the documentation
