### PR TITLE
Revert "fix functionsR load"

### DIFF
--- a/array/DNAm/preprocessing/loadDataGDS.r
+++ b/array/DNAm/preprocessing/loadDataGDS.r
@@ -34,7 +34,7 @@ library(IlluminaHumanMethylationEPICmanifest)
 library(IlluminaHumanMethylation450kanno.ilmn12.hg19)
 library(IlluminaHumanMethylation450kmanifest)
 library(devtools)
-devtools::load_all(path = "~/BrainFANS/functionsR")
+devtools::load_all(path = "../functionsR")
 
 
 


### PR DESCRIPTION
Reverts ejh243/BrainFANS#64

The proposed changes do not actually fix the problem. The files still won't load if BrainFANS is not located in the user's home directory.