### PR TITLE
add shellcheck workflow

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,19 @@
+name: shellcheck
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+permissions: read
+
+jobs:
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master
+        with:
+          severity: error

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -15,5 +15,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@master
+        env:
+          SHELLCHECK_OPTS: -e SC1090 -e SC2086 # Doesn't complain about the inability to find a source file, and doesn't complain about using quotes
         with:
           severity: error
+          format: tty


### PR DESCRIPTION
# Description

This pull request will add shellcheck to the list of workflows in the repository. This should look through the shell scripts in the repository and only output the critical errors that it finds. This will be things like crlf eol and incorrect use of commands (*etc.*).

## Issue ticket number

This pull request is to address issue: #76.

## Type of pull request

- [ ] Bug fix
- [x] New feature/enhancement
- [ ] Code refactor
- [ ] Documentation update

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my code to check that it is functional
- [ ] I have used linters to check for common sources of errors
- [ ] I have implemented fail safes in my code to account for edge cases
- [ ] I have made the corresponding changes to the documentation
