### PR TITLE
add superlinter

### DIFF
--- a/.github/linters/.lintr
+++ b/.github/linters/.lintr
@@ -1,0 +1,14 @@
+linters: with_defaults(
+  duplicate_argument_linter,
+  equals_na_linter,
+  length_test_linter,
+  missing_argument_linter,
+  missing_package_linter,
+  redundant_equals_linter,
+  sprintf_linter,
+  unused_import_linter,
+  cyclocomp_linter,
+  indentation_linter,
+  vector_logic_linter,
+  line_length_linter(300)
+)

--- a/.github/linters/.shellcheckrc
+++ b/.github/linters/.shellcheckrc
@@ -1,0 +1,3 @@
+# Disables linters for source commands not being evaluated, variables not
+# being wrapped in quotes and cd commands not having "|| exit" after them
+disable=SC1090,SC2086,SC2164

--- a/.github/workflows/super-lint.yml
+++ b/.github/workflows/super-lint.yml
@@ -12,6 +12,7 @@ jobs:
 
     permissions:
       contents: read
+      packages: read
       # To report GitHub Actions status checks
       statuses: write
 

--- a/.github/workflows/super-lint.yml
+++ b/.github/workflows/super-lint.yml
@@ -4,6 +4,7 @@ name: Lint
 on:
   push:
     branches-ignore: [master]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/super-lint.yml
+++ b/.github/workflows/super-lint.yml
@@ -32,4 +32,5 @@ jobs:
           VALIDATE_ALL_CODEBASE: false
           BASH_SEVERITY: error
           LOG_LEVEL: error
+          VALIDATE_CHECKOV: false
 ...

--- a/.github/workflows/super-lint.yml
+++ b/.github/workflows/super-lint.yml
@@ -14,7 +14,6 @@ jobs:
 
     permissions:
       contents: read
-      packages: read
       # To report GitHub Actions status checks
       statuses: write
 
@@ -33,4 +32,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEFAULT_BRANCH: master
           VALIDATE_ALL_CODEBASE: false
+          BASH_SEVERITY: error
+          LOG_LEVEL: error
 ...

--- a/.github/workflows/super-lint.yml
+++ b/.github/workflows/super-lint.yml
@@ -1,0 +1,32 @@
+---
+name: Lint
+
+on:
+  [ push, pull_request]
+
+jobs:
+  build:
+    name: Lint code base
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: read
+      # To report GitHub Actions status checks
+      statuses: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          # super-linter needs the full git history to get the
+          # list of files that changed across commits
+          fetch-depth: 0
+
+      - name: Super-linter
+        uses: super-linter/super-linter@v6.3.0  # x-release-please-version
+        env:
+          # To report GitHub Actions status checks
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEFAULT_BRANCH: master
+...

--- a/.github/workflows/super-lint.yml
+++ b/.github/workflows/super-lint.yml
@@ -2,7 +2,10 @@
 name: Lint
 
 on:
-  [ push, pull_request]
+  push:
+    branches-ignore: [master]
+  pull_request:
+    branches: [master]
 
 jobs:
   build:
@@ -29,4 +32,5 @@ jobs:
           # To report GitHub Actions status checks
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEFAULT_BRANCH: master
+          VALIDATE_ALL_CODEBASE: false
 ...

--- a/.github/workflows/super-lint.yml
+++ b/.github/workflows/super-lint.yml
@@ -4,8 +4,6 @@ name: Lint
 on:
   push:
     branches-ignore: [master]
-  pull_request:
-    branches: [master]
 
 jobs:
   build:

--- a/.github/workflows/super-lint.yml
+++ b/.github/workflows/super-lint.yml
@@ -33,4 +33,5 @@ jobs:
           BASH_SEVERITY: error
           LOG_LEVEL: error
           VALIDATE_CHECKOV: false
+          CREATE_LOG_FILE: true
 ...


### PR DESCRIPTION
# Description

This pull request will add the super linter to lint files. This has the added benefit of only looking at files that have been changed and is actively worked on. It also means there is just one workflow that lints all the files, instead of multiple.

## Issue ticket number

This pull request is to address issue: #76.

## Type of pull request

- [ ] Bug fix
- [x] New feature/enhancement
- [ ] Code refactor
- [ ] Documentation update

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my code to check that it is functional
- [x] I have used linters to check for common sources of errors
- [ ] I have implemented fail safes in my code to account for edge cases
- [ ] I have made the corresponding changes to the documentation
