### PR TITLE
Add page summarizing git workflow

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+# Contributing Guidelines
+
+Thank you for your interest in contributing to BrainFANS! 
+
+Our contribution guide is given on the development pages of the associated
+BrainFANS website which can be found
+[here](https://ejh243.github.io/BrainFANS/Developer-information/Contributing-to-repository/Git-workflow-overview).

--- a/documentation/docs/Developer-information/Contributing-to-repository/Git-workflow-overview.md
+++ b/documentation/docs/Developer-information/Contributing-to-repository/Git-workflow-overview.md
@@ -1,0 +1,102 @@
+---
+sidebar_position: 7
+title: Overview of our git workflow
+description: An overview of the process outlined in the contributions guide
+---
+
+# Overview of our git workflow
+
+Thank you for your interest in contributing to BrainFANS! 
+
+This page covers an overview of the expected git workflow for the BrainFANS
+repository. If any steps are confusing (or too brief), please consult the full 
+[contributions guide](./_category_.json).
+
+## Choose an issue
+
+Do not work on the repository before assigning yourself (or asking to be 
+assigned) to an existing [issue](https://github.com/ejh243/BrainFANS/issues).
+Create an issue if none currently apply to what you want to change.
+
+## Update your local repository
+
+Do not work on an outdated version of the repository. Sync your local version
+of BrainFANS with `git fetch` regularly to avoid excessive merge conflicts.
+
+## Resolve the issue
+
+Create a new feature branch, either from 'master' or an existing development
+branch. Then make your changes there.
+
+:::warning[atomic commits]
+Please keep your commits 
+['atomic'](https://en.wikipedia.org/wiki/Atomic_commit) if possible. Bugs
+introduced in a 200 line changing commit are harder to isolate.
+:::
+
+```mermaid
+---
+title: Creating a new feature branch
+---
+%%{init: { 'logLevel': 'debug', 'theme': 'base', 'gitGraph': {'showBranches': true, 'showCommitLabel':true,'mainBranchName': 'master'}} }%%
+  gitGraph
+    commit id: " "
+    branch your-feature-branch
+    commit id: "Atomic commit 1"
+    commit id: "Atomic commit 2"
+    commit id: "Atomic commit 3"
+```
+
+## Create a pull request
+
+Before making a pull request, try to mitigate merge conflicts by merging
+the master branch (or development branch) into your feature branch first.
+
+```mermaid
+---
+title: Creating a pull request
+---
+%%{init: { 'logLevel': 'debug', 'theme': 'base', 'gitGraph': {'showBranches': true, 'showCommitLabel':true,'mainBranchName': 'master'}} }%%
+  gitGraph
+    commit id: " "
+    branch your-feature-branch
+    commit id: "Atomic commit 1"
+    commit id: "Atomic commit 2"
+    commit id: "Atomic commit 3"
+    checkout master
+    commit id: "Other changes"
+    commit id: "other changes"
+    checkout your-feature-branch
+    merge master tag: "Merge from master"
+    commit id: "Fix possible merge conflicts"
+    checkout master
+    merge your-feature-branch tag: "Your pull request"
+```
+
+When creating a pull request, please make sure you fill in the template
+properly. Give a concise description, link the issue(s) you have resolved and
+be honest in the checklist. Assign a reviewer to the pull request if possible,
+if not, we will do this for you.
+
+:::warning[Large pull requests]
+Please try to keep your pull requests small. Sometimes this is unavoidable, we
+understand this. Pull requests that exceed 400 lines of changes are
+unlikely to be reviewed unless your reviewer is being particularly nice that
+day.
+:::
+
+## Finalise pull request
+
+During the review process, you may be asked to make minor changes or to resolve
+merge conflicts. Make sure to check how the pull request is coming along and
+engage in conversation with the reviewer and other contributors.
+
+After the pull request is approved, you can squash merge your branch into
+master (or the development branch). Again, if you are unable to do this, we
+will do this for you.
+
+Thank you very much for your time and effort, it is truly appreciated!
+
+If you are reading this, thank you so much for reading our guidelines future
+developer! To show that you have read this guide, put a :brain: into your pull
+request anywhere by typing `:brain:`.

--- a/documentation/docs/Developer-information/Contributing-to-repository/Git-workflow-overview.md
+++ b/documentation/docs/Developer-information/Contributing-to-repository/Git-workflow-overview.md
@@ -16,7 +16,9 @@ repository. If any steps are confusing (or too brief), please consult the full
 
 Do not work on the repository before assigning yourself (or asking to be 
 assigned) to an existing [issue](https://github.com/ejh243/BrainFANS/issues).
-Create an issue if none currently apply to what you want to change.
+Create an issue that follows our 
+[issue guidelines](../../User-information/Creating_issues/Good-issue-practices.md) if 
+none currently apply to what you want to change.
 
 ## Update your local repository
 


### PR DESCRIPTION
# Description

This pull request will make a summary of the pushed git workflow for BrainFANS on the developer pages of the website. This page will be linked in CONTRIBUTING file that is located in `.github`. If a user goes to the pull requests tab on this repository and has yet to create a pull request, they will see a message like this:

<p align="center">
<img src="https://github.com/ejh243/BrainFANS/assets/147140110/5b65eabd-9167-4b36-b6f9-cfa1e4e5f61b">
</p>
The contributing guidelines will link to CONTRIBUTING.md which subsequently links to the contribution guide summary that is bundled with this pull request.

## Issue ticket number

This pull request is to address issue: #91.

## Type of pull request

- [ ] Bug fix
- [x] New feature/enhancement
- [ ] Code refactor
- [x] Documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code to check that it is functional
- [ ] I have used linters to check for common sources of errors
- [ ] I have implemented fail safes in my code to account for edge cases
- [x] I have made the corresponding changes to the documentation
