### PR TITLE
Add how to remove stale branches

### DIFF
--- a/documentation/docs/Developer-information/Contributing-to-repository/Finalise-pull-request.md
+++ b/documentation/docs/Developer-information/Contributing-to-repository/Finalise-pull-request.md
@@ -88,8 +88,11 @@ git status
 git checkout master
 git branch -d <your-branch-name>
 
+# Remove any stale origin branches 
+git remote prune origin
+
 # Verify the deletion (your branch should not appear in the output)
-git branch
+git branch -a
 ```
 
 ## Mark related issues as complete


### PR DESCRIPTION
# Description

This pull request will tell the user how to remove any stale branches that have been deleted on GitHub (but not yet deleted in the .git/refs/remotes/origin folder). Simply using `git branch -d` will only delete the local version of the branch located in .git/refs/heads.

## Issue ticket number

This pull request is to address issue: #101.

## Type of pull request

- [ ] Bug fix
- [ ] New feature/enhancement
- [ ] Code refactor
- [x] Documentation update

## Checklist

- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code to check that it is functional
- [ ] I have used linters to check for common sources of errors
- [ ] I have implemented fail safes in my code to account for edge cases
- [ ] I have made the corresponding changes to the documentation
