### PR TITLE
Provide a warning message if GenotypeIID column is missing

### DIFF
--- a/array/DNAm/preprocessing/calcQCMetrics.r
+++ b/array/DNAm/preprocessing/calcQCMetrics.r
@@ -341,7 +341,7 @@ if(!"genoCheck"%in% colnames(QCmetrics) & file.exists(genoFile)){
 	geno<-read.table(genoFile, stringsAsFactors = FALSE, header = TRUE)
 	geno.all<-geno
 
-	indexIID <- grep("^Genotype.IID$", names(QCmetric), ignore.case=TRUE)
+	indexIID <- grep("^Genotype.IID$", names(QCmetrics), ignore.case=TRUE)
 	if (length(indexIID) != 1){
 		message("Warning: Genotype.IID column is missing, unable to compare external SMP data.")
 	}else{
@@ -426,7 +426,7 @@ closefn.gds(gfile)
 write.csv(QCmetrics, paste0(dataDir, "/2_gds/QCmetrics/QCMetricsPostSampleCheck.csv"))
 
 # save QC metrics and SNP correlations to generate QC report
-if(file.exists(genoFile)){
+if(file.exists(genoFile) & length(indexIID) == 1 ){
 	save(QCmetrics, snpCor, betas.pca, ctrl.pca, pFOut, geno.mat, betas.rs, rsbetas, file = qcData)
 } else {
 	save(QCmetrics, snpCor, betas.pca, ctrl.pca, pFOut, rsbetas, file = qcData)

--- a/array/DNAm/preprocessing/calcQCMetrics.r
+++ b/array/DNAm/preprocessing/calcQCMetrics.r
@@ -343,7 +343,7 @@ if(!"genoCheck"%in% colnames(QCmetrics) & file.exists(genoFile)){
 
 	indexIID <- grep("^Genotype.IID$", names(QCmetrics), ignore.case=TRUE)
 	if (length(indexIID) != 1){
-		message("Warning: Genotype.IID column is missing, unable to compare external SMP data.")
+		message("Warning: Genotype.IID column is missing, unable to compare external SNP data.")
 	}else{
 	   geno<-geno[match(QCmetrics$Genotype.IID, geno$IID),]
 	   rsIDs<-gsub("_.", "", colnames(geno)[-c(1:6)])


### PR DESCRIPTION
# Description

This pull request will provide a warning when GenotypeIID column is missing, and save the rest of QCmetrics.

## Issue ticket number

This pull request is to address issue: #105.

## Type of pull request

- [x] Bug fix
- [ ] New feature/enhancement
- [ ] Code refactor
- [ ] Documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code to check that it is functional
- [ ] I have used linters to check for common sources of errors
- [ ] I have implemented fail safes in my code to account for edge cases
- [ ] I have made the corresponding changes to the documentation
