### PR TITLE
fix dcf again

### DIFF
--- a/.github/linters/.lintr
+++ b/.github/linters/.lintr
@@ -10,6 +10,4 @@ linters: with_defaults(
     cyclocomp_linter,
     indentation_linter,
     vector_logic_linter,
-    line_length_linter(300)
-  )
-
+    line_length_linter(300))


### PR DESCRIPTION
When parsing this file with read.dcf, it doesn't like  the closing ")" character to be on its own. I have no idea why

## Type of pull request

- [x] Bug fix
- [ ] New feature/enhancement
- [ ] Code refactor
- [ ] Documentation update

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my code to check that it is functional
- [ ] I have used linters to check for common sources of errors
- [ ] I have implemented fail safes in my code to account for edge cases
- [ ] I have made the corresponding changes to the documentation
