### PR TITLE
For stage 2 QC of DNAm make robust to sex or snp check being turned off

### DIFF
--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -69,21 +69,28 @@ if(sexCheck){
  	QCSum<-cbind(QCSum, NA)
 }
 colnames(QCSum)[ncol(QCSum)]<-"sexCheck"
-if(snpCheck){
+
+if(snpCheck & "genoCheck"%in% colnames(QCmetrics)){
 	QCSum<-cbind(QCSum, QCmetrics$genoCheck > 0.8)
 }else{
  	QCSum<-cbind(QCSum, NA)
 }
 colnames(QCSum)[ncol(QCSum)]<-"snpCheck"
 
-QCSum<-cbind(QCSum, rowSums(QCSum[,c("passQCS1", "sexCheck", "snpCheck")], na.rm = TRUE) == rowSums(!is.na(QCSum[,c("passQCS1", "sexCheck", "snpCheck")])))
+# if neither sex check or snp check performed stage two pass status is copied from stage one 
+cols<-c("passQCS1", "sexCheck", "snpCheck")
+cols<-cols[cols %in% colnames(QCSum)]
+if(length(cols) > 1){
+	QCSum<-cbind(QCSum, rowSums(QCSum[,cols], na.rm = TRUE) == rowSums(!is.na(QCSum[,cols])))
+} else {
+	QCSum<-cbind(QCSum, QCSum[,"passQCS1"])
+}
 colnames(QCSum)[ncol(QCSum)]<-"passQCS2"
 rownames(QCSum)<-QCmetrics$Basename
 
 write.csv(cbind(QCmetrics[,c("Basename", "Sample_ID", "Individual_ID", "Cell_Type")], QCSum),  paste0(dataDir, "/2_gds/QCmetrics/PassQCStatusAllSamples.csv"))
 
 QCmetrics<-cbind(QCmetrics,QCSum[,c("passQCS1", "passQCS2")])
-
 
 
 ```


### PR DESCRIPTION
# Description

This pull request will fix a bug in the QC.rmd script, where is snpCheck or genoCheck are set to false it still expects there output to be in the QC summary. 

## Issue ticket number 

This pull request is to address issue: #125 

## Type of pull request

- [X] Bug fix
- [ ] New feature/enhancement
- [ ] Code refactor
- [ ] Documentation update

## Checklist

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have tested my code to check that it is functional
- [ ] I have used linters to check for common sources of errors
- [ ] I have implemented fail safes in my code to account for edge cases
- [ ] I have made the corresponding changes to the documentation
