### PR TITLE
change linters used

### DIFF
--- a/.github/linters/.lintr
+++ b/.github/linters/.lintr
@@ -1,14 +1,8 @@
-linters: linters_with_defaults(
+linters: linters_with_tags(
+    tags = c("best_practices", "robustness",  "common_mistakes"),
     line_length_linter(300),
-    indentation_linter = NULL,
-    object_name_linter = NULL,
-    object_usage_linter = NULL,
-    cyclocomp_linter = NULL,
-    seq_linter = NULL,
-    spaces_inside_linter = NULL,
-    trailing_whitespace_linter = NULL,
-    assignment_linter = NULL,
-    infix_spaces_linter = NULL,
-    object_length_linter(50)
+    T_and_F_symbol_linter = NULL,
+    implicit_integer_linter = NULL,
+    undesirable_function_linter = NULL
   )
 


### PR DESCRIPTION
# Description

This pull request will alter the linters that are used by lintr. They should be mainly focused around best practices, robustness and common mistakes according to the tags. I have tested this in a repo of mine and got rid of a few linters that I assume we don't care about (like using TRUE over T). I'm sure that a couple of the linters included under these tags will be annoying in the future, so I'll remove them when they pop up.

## Issue ticket number

This pull request is to address issue: #133.

## Type of pull request

- [ ] Bug fix
- [ ] New feature/enhancement
- [x] Code refactor
- [ ] Documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code to check that it is functional
- [ ] I have used linters to check for common sources of errors
- [ ] I have implemented fail safes in my code to account for edge cases
- [ ] I have made the corresponding changes to the documentation
