### PR TITLE
remove namespace_linter

### DIFF
--- a/.github/linters/.lintr
+++ b/.github/linters/.lintr
@@ -3,6 +3,7 @@ linters: linters_with_tags(
     line_length_linter(300),
     T_and_F_symbol_linter = NULL,
     implicit_integer_linter = NULL,
-    undesirable_function_linter = NULL
+    undesirable_function_linter = NULL,
+    namespace_linter = NULL
   )
 


### PR DESCRIPTION
# Description

This pull request will remove the namespace_linter from lintr. It is just proccing for certain packages like BiocManager, which obviously works fine if you have the package installed. It isn't really giving any useful information therefore (most times it comes up will be a false positive). Probably best to remove it.

## Issue ticket number

This pull request is to address issue: #134 .

## Type of pull request

- [ ] Bug fix
- [ ] New feature/enhancement
- [x] Code refactor
- [ ] Documentation update

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my code to check that it is functional
- [ ] I have used linters to check for common sources of errors
- [ ] I have implemented fail safes in my code to account for edge cases
- [ ] I have made the corresponding changes to the documentation
