### PR TITLE
Add advice to guide on using the `--rebase` flag when pulling

### DIFF
--- a/documentation/docs/Developer-information/Contributing-to-repository/Create-pull-request.md
+++ b/documentation/docs/Developer-information/Contributing-to-repository/Create-pull-request.md
@@ -55,7 +55,7 @@ error: Failed to merge in the changes.
 Patch failed at commit commit-name
 ```
 
-If you do get this error, enter the following instead:
+If you do get this error, enter the following:
 
 ```bash
 # Discard the rebase

--- a/documentation/docs/Developer-information/Contributing-to-repository/Create-pull-request.md
+++ b/documentation/docs/Developer-information/Contributing-to-repository/Create-pull-request.md
@@ -33,7 +33,7 @@ Once any merge conflicts that arise from the above have been resolved, you can p
 
 ```bash
 # Push your changes to the remote repository
-git push origin your-branch-name
+git push -u origin your-branch-name
 ```
 
 :::warning[multiple people working on the same branch]
@@ -41,13 +41,36 @@ If you are working on the same branch with other people and the branch has alrea
 
 ```bash
 # Pull the latest changes from the remote repository
-git pull origin your-branch-name
+git pull --rebase origin your-branch-name
 
 # Push your changes to the remote repository
 git push origin your-branch-name
 ```
 
-This will ensure that you are not causing any merge conflicts when you go to push your changes. `git pull` will merge the version online with your local version of the branch. Warnings of merge conflicts will appear in the terminal if they are apparent at this stage. Fix these before pushing.
+Note that sometimes you will get this error:
+
+```text
+CONFLICT (content): Merge conflict in filename.extension
+error: Failed to merge in the changes.
+Patch failed at commit commit-name
+```
+
+If you do get this error, enter the following instead:
+
+```bash
+# Discard the rebase
+git rebase --abort
+
+# Complete a normal pull
+git pull origin your-branch-name
+
+# Work through the merge conflicts that likely caused --rebase to fail
+
+# Push your changes to the remote repository
+git push origin your-branch-name
+```
+
+This will ensure that you are not causing any merge conflicts for others when you go to push your changes. `git pull` will merge the version online with your local version of the branch. Warnings of merge conflicts will appear in the terminal if they are apparent at this stage. Fix these before pushing.
 :::
 
 ## Return to github to finalise the pull request


### PR DESCRIPTION
# Description

This pull request will ask developers to default to using git pull `--rebase` when working with others on the same branch. This way there will be less merge commits that bloat pull requests. I also added a quick paragraph that explains what to do if the `--rebase` flag fails.

## Issue ticket number

This pull request is to address issue: #136.

## Type of pull request

- [ ] Bug fix
- [ ] New feature/enhancement
- [ ] Code refactor
- [x] Documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code to check that it is functional
- [ ] I have used linters to check for common sources of errors
- [ ] I have implemented fail safes in my code to account for edge cases
- [x] I have made the corresponding changes to the documentation
