### PR TITLE
Update advice to reliably correct commits being made to master

### DIFF
--- a/documentation/docs/Developer-information/Contributing-to-repository/Resolving-the-issue.md
+++ b/documentation/docs/Developer-information/Contributing-to-repository/Resolving-the-issue.md
@@ -63,8 +63,13 @@ In such cases, you will need to stash your changes before switching branches.
 To do this, enter the following commands into the terminal.
 
 ```bash
+# Stash your changes
 git stash push
+
+# Move over to your development branch without needing to commit your changes
 git checkout your-branch-name
+
+# Bring your changes back to your workspace from the stash
 git stash pop
 ```
 


### PR DESCRIPTION
# Description

This pull request will change the code snippet on page:
https://ejh243.github.io/BrainFANS/Developer-information/Contributing-to-repository/Resolving-the-issue
So that the developer can more reliably revert their accidental commits to the master branch (in case they made multiple commits already). The previous advice only accounted for the scenario where one commit was accidently made. 

On top of this, sometimes you might get the following message upon using `git checkout`:

```
error: Your local changes to the following files would be overwritten by checkout:
    somedir/somefile.extension
Please, commit your changes or stash them before you can switch branches.
Aborting
```

In such cases, the developer needs to use `git stash` commands. These have been added to the section for further clarity in case this error message pops up.

## Issue ticket number

This pull request is to address issue: #144.

## Type of pull request

- [ ] Bug fix
- [ ] New feature/enhancement
- [ ] Code refactor
- [x] Documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code to check that it is functional
- [ ] I have used linters to check for common sources of errors
- [x] I have implemented fail safes in my code to account for edge cases
- [x] I have made the corresponding changes to the documentation
