### PR TITLE
Use full file paths instead of globs in s/f tests

### DIFF
--- a/sequencing/BSSeq/preprocessing/calcQCMetrics.sh
+++ b/sequencing/BSSeq/preprocessing/calcQCMetrics.sh
@@ -53,7 +53,7 @@ fi
 
 #cd $METHYLDIR
 
-#zcat ${sampleName}*bismark.cov.gz | grep "chr1	" > ENCODEMetrics/${sampleName}.chr1.cov.bg
+#zcat ${sampleName}*bismark.cov.gz | grep "chr1	" > ENCODEMetrics/${sampleName}.chr2.cov.bg
 
 if [[ $? == 0 ]]
 	then echo "Part 1 ENCODE metrics calculated"

--- a/sequencing/BSSeq/preprocessing/calcQCMetrics.sh
+++ b/sequencing/BSSeq/preprocessing/calcQCMetrics.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 ## calculates ENCODE library complexity metrics (taken from https://docs.google.com/document/d/1f0Cm4vRyDQDu0bMehHD7P7KOMxTOP-HiNoIvL1VcBt8/edit#)
 
 ## EXECUTION

--- a/sequencing/BSSeq/preprocessing/calcQCMetrics.sh
+++ b/sequencing/BSSeq/preprocessing/calcQCMetrics.sh
@@ -54,7 +54,7 @@ fi
 
 #cd $METHYLDIR
 
-#zcat ${sampleName}*bismark.cov.gz | grep "chr1	" > ENCODEMetrics/${sampleName}.chr2.cov.bg
+#zcat ${sampleName}*bismark.cov.gz | grep "chr1	" > ENCODEMetrics/${sampleName}.chr1.cov.bg
 
 if [[ $? == 0 ]]
 	then echo "Part 1 ENCODE metrics calculated"

--- a/sequencing/BSSeq/preprocessing/progressReport.sh
+++ b/sequencing/BSSeq/preprocessing/progressReport.sh
@@ -67,7 +67,7 @@ echo "Number of bismark methylation files found " $(ls ${METHYLDIR}/*bismark.cov
 ## save output in txt file
 echo "sampleID,dataFolder,R1Filename,R2Filename,FASTQCR1,FASTQCR2,TRIMGALORE,BISMARK,BISMnodup,ENCODEMetrics,METHYLATION" > ${METADIR}/summariseSampleProcessingProgress.csv
 
-for sampleName in ${SAMPLEIDS[@]}
+for sampleName in "${SAMPLEIDS[@]}"
 do 
     toProcess=($(find ${RAWDATADIR} -maxdepth 1 -name ${sampleName}'*'))
     
@@ -76,60 +76,60 @@ do
     toProcess=($(sort <<<"${toProcess[*]}")) ## sort so that the first element is R1
     unset IFS 
 
-    echo "Processing" ${sampleName}
-    f1=$(basename ${toProcess[0]}) 
-    f2=$(basename ${toProcess[1]})
+    echo "Processing" "${sampleName}"
+    f1=$(basename "${toProcess[0]}") 
+    f2=$(basename "${toProcess[1]}")
 
-    echo -n ${sampleName},${RAWDATADIR},${f1},${f2}, >> ${METADIR}/summariseSampleProcessingProgress.csv
+    echo -n ${sampleName},${RAWDATADIR},${f1},${f2}, >> "${METADIR}/summariseSampleProcessingProgress.csv"
 
     
-    if [ ! -s ${FASTQCDIR}/${f1%%.*}*fastqc.zip ]
+    if [ ! -s "${FASTQCDIR}/${f1%%.*}_fastqc.zip" ]
     then
-        echo -n "N," >> ${METADIR}/summariseSampleProcessingProgress.csv
+        echo -n "N," >> "${METADIR}/summariseSampleProcessingProgress.csv"
     else
-        echo -n "Y," >> ${METADIR}/summariseSampleProcessingProgress.csv
+        echo -n "Y," >> "${METADIR}/summariseSampleProcessingProgress.csv"
     fi
     
-    if [ ! -s ${FASTQCDIR}/${f2%%.*}*fastqc.zip ]
+    if [ ! -s "${FASTQCDIR}/${f2%%.*}_fastqc.zip" ]
     then
-        echo -n "N," >> ${METADIR}/summariseSampleProcessingProgress.csv
+        echo -n "N," >> "${METADIR}/summariseSampleProcessingProgress.csv"
     else
-        echo -n "Y," >> ${METADIR}/summariseSampleProcessingProgress.csv
+        echo -n "Y," >> "${METADIR}/summariseSampleProcessingProgress.csv"
     fi
 
-    if [ ! -s ${TRIMDIR}/trimGaloreReports/${sampleName}*.txt ]
+    if [ ! -s "${TRIMDIR}/trimGaloreReports/${sampleName}.fastqc.gz_trimming_report.txt" ]
     then
-        echo -n "N," >> ${METADIR}/summariseSampleProcessingProgress.csv
+        echo -n "N," >> "${METADIR}/summariseSampleProcessingProgress.csv"
     else
-        echo -n "Y," >> ${METADIR}/summariseSampleProcessingProgress.csv
+        echo -n "Y," >> "${METADIR}/summariseSampleProcessingProgress.csv"
     fi
     
-    if [ ! -s ${ALIGNEDDIR}/${sampleName}*pe.bam ]
+    if [ ! -s "${ALIGNEDDIR}/${sampleName}_1_val_1_bismark_bt2_pe.bam" ]
     then
-        echo -n "N," >> ${METADIR}/summariseSampleProcessingProgress.csv
+        echo -n "N," >> "${METADIR}/summariseSampleProcessingProgress.csv"
     else
-        echo -n "Y," >> ${METADIR}/summariseSampleProcessingProgress.csv
+        echo -n "Y," >> "${METADIR}/summariseSampleProcessingProgress.csv"
     fi
     
-    if [ ! -s ${ALIGNEDDIR}/${sampleName}*nodup.bam ]
+    if [ ! -s "${ALIGNEDDIR}/${sampleName}.nodup.bam" ]
     then
-        echo -n "N," >> ${METADIR}/summariseSampleProcessingProgress.csv
+        echo -n "N," >> "${METADIR}/summariseSampleProcessingProgress.csv"
     else
-        echo -n "Y," >> ${METADIR}/summariseSampleProcessingProgress.csv
+        echo -n "Y," >> "${METADIR}/summariseSampleProcessingProgress.csv"
     fi
     
-    if [ ! -s ${ALIGNEDDIR}/ENCODEMetrics/${sampleName}*.qc ]
+    if [ ! -s "${ALIGNEDDIR}/ENCODEMetrics/${sampleName}.qc" ]
     then
-        echo -n "N," >> ${METADIR}/summariseSampleProcessingProgress.csv
+        echo -n "N," >> "${METADIR}/summariseSampleProcessingProgress.csv"
     else
-        echo -n "Y," >> ${METADIR}/summariseSampleProcessingProgress.csv
+        echo -n "Y," >> "${METADIR}/summariseSampleProcessingProgress.csv"
     fi
     
-    if [ ! -s ${METHYLDIR}/${sampleName}*bismark.cov.gz ]
+    if [ ! -s "${METHYLDIR}/${sampleName}.nodup.bismark.cov.gz" ]
     then
-        echo "N" >> ${METADIR}/summariseSampleProcessingProgress.csv
+        echo "N" >> "${METADIR}/summariseSampleProcessingProgress.csv"
     else
-        echo "Y" >> ${METADIR}/summariseSampleProcessingProgress.csv
+        echo "Y" >> "${METADIR}/summariseSampleProcessingProgress.csv"
     fi
   
 done

--- a/sequencing/BSSeq/preprocessing/progressReport.sh
+++ b/sequencing/BSSeq/preprocessing/progressReport.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 ## searches for output files from each part of the QC pipeline and reports number of files found
 ## then searches specifically for each sample to identify what is missing
 

--- a/sequencing/ChIPSeq/preprocessing/calcENCODEQCMetrics.sh
+++ b/sequencing/ChIPSeq/preprocessing/calcENCODEQCMetrics.sh
@@ -36,7 +36,7 @@ mkdir -p ENCODEMetrics
 samtools sort -n --threads 10 ${sampleName}.filt.nodup.bam -O SAM  | SAMstats --sorted_sam_file -  --outf ENCODEMetrics/${sampleName}.flagstat.qc
 
 
-if [ ! -f ${sampleName}*pbc.qc ]
+if [ ! -f "${sampleName}.pbc.qc" ]
 then
 	# COMPUTE LIBRARY COMPLEXITIY
 

--- a/sequencing/ChIPSeq/preprocessing/calcENCODEQCMetrics.sh
+++ b/sequencing/ChIPSeq/preprocessing/calcENCODEQCMetrics.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 ## taken from ENCODE pipeline https://docs.google.com/document/d/1lG_Rd7fnYgRpSIqrIfuVlAz2dW1VaSQThzk836Db99c/edit
 
 ## EXECUTION

--- a/sequencing/ChIPSeq/preprocessing/calcFrip.sh
+++ b/sequencing/ChIPSeq/preprocessing/calcFrip.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 ## calculates number of reads within peaks for sample level peaks
 
 ## EXECUTION

--- a/sequencing/ChIPSeq/preprocessing/calcFrip.sh
+++ b/sequencing/ChIPSeq/preprocessing/calcFrip.sh
@@ -44,10 +44,10 @@ fi
 
 ## MACS2 peaks called from bam files with paired end flag
 
-if [ -s ${PEAKDIR}/${sampleName}*Peak.filt ]
+if [ -s "${PEAKDIR}/${sampleName}.narrowPeak.filt" ] || [ -s "${PEAKDIR}/${sampleName}.broadPeak.filt"  ]
 then
 	echo -n $(wc -l ${PEAKDIR}/${sampleName}*Peak.filt | cut -f1 -d' '), >> ${PEAKDIR}/QCOutput/FRIP_${sampleName}.csv
 	echo $(bedtools sort -i ${PEAKDIR}/${sampleName}*Peak.filt | bedtools merge -i stdin | bedtools intersect -u -a ${ALIGNEDDIR}/${sampleName}.filt.nodup.bam -b stdin -ubam | samtools view -c) >> ${PEAKDIR}/QCOutput/FRIP_${sampleName}.csv
 else
-	echo NA,NA >> ${PEAKDIR}/QCOutput/FRIP_${sampleName}.csv
+	echo NA,NA >> "${PEAKDIR}/QCOutput/FRIP_${sampleName}.csv"
 fi

--- a/sequencing/ChIPSeq/preprocessing/progressReport.sh
+++ b/sequencing/ChIPSeq/preprocessing/progressReport.sh
@@ -83,53 +83,53 @@ do
     echo -n ${sampleName},${RAWDATADIR}, ${f1},${f2}, >> ${METADIR}/summariseSampleProcessingProgress.csv
 
     
-    if [ ! -s ${FASTQCDIR}/${f1%.f*}fastqc.zip ]
+    if [ ! -s "${FASTQCDIR}/${f1%.f*}_fastqc.zip" ]
     then
-        echo -n "N," >> ${METADIR}/summariseSampleProcessingProgress.csv
+        echo -n "N," >> "${METADIR}/summariseSampleProcessingProgress.csv"
     else
-        echo -n "Y," >> ${METADIR}/summariseSampleProcessingProgress.csv
+        echo -n "Y," >> "${METADIR}/summariseSampleProcessingProgress.csv"
     fi
     
-    if [ ! -s ${FASTQCDIR}/${f2%.f*}fastqc.zip ]
+    if [ ! -s "${FASTQCDIR}/${f2%.f*}_fastqc.zip" ]
     then
-        echo -n "N," >> ${METADIR}/summariseSampleProcessingProgress.csv
+        echo -n "N," >> "${METADIR}/summariseSampleProcessingProgress.csv"
     else
-        echo -n "Y," >> ${METADIR}/summariseSampleProcessingProgress.csv
+        echo -n "Y," >> "${METADIR}/summariseSampleProcessingProgress.csv"
     fi
 
-    if [ ! -s ${TRIMDIR}/fastp_reports/${sampleName}*.json ]
+    if [ ! -s "${TRIMDIR}/fastp_reports/${sampleName}_fastp.json" ]
     then
-        echo -n "N," >> ${METADIR}/summariseSampleProcessingProgress.csv
+        echo -n "N," >> "${METADIR}/summariseSampleProcessingProgress.csv"
     else
-        echo -n "Y," >> ${METADIR}/summariseSampleProcessingProgress.csv
+        echo -n "Y," >> "${METADIR}/summariseSampleProcessingProgress.csv"
     fi
     
-    if [ ! -s ${ALIGNEDDIR}/${sampleName}.bowtie.log ]
+    if [ ! -s "${ALIGNEDDIR}/${sampleName}.bowtie.log" ]
     then
-        echo -n "N," >> ${METADIR}/summariseSampleProcessingProgress.csv
+        echo -n "N," >> "${METADIR}/summariseSampleProcessingProgress.csv"
     else
-        echo -n "Y," >> ${METADIR}/summariseSampleProcessingProgress.csv
+        echo -n "Y," >> "${METADIR}/summariseSampleProcessingProgress.csv"
     fi
     
-    if [ ! -s ${ALIGNEDDIR}/${sampleName}.filt.nodup.bam ]
+    if [ ! -s "${ALIGNEDDIR}/${sampleName}.filt.nodup.bam" ]
     then
-        echo -n "N," >> ${METADIR}/summariseSampleProcessingProgress.csv
+        echo -n "N," >> "${METADIR}/summariseSampleProcessingProgress.csv"
     else
-        echo -n "Y," >> ${METADIR}/summariseSampleProcessingProgress.csv
+        echo -n "Y," >> "${METADIR}/summariseSampleProcessingProgress.csv"
     fi
     
-    if [ ! -s ${ALIGNEDDIR}/ENCODEMetrics/${sampleName}*.pbc.qc ]
+    if [ ! -s "${ALIGNEDDIR}/ENCODEMetrics/${sampleName}.pbc.qc" ]
     then
-        echo -n "N," >> ${METADIR}/summariseSampleProcessingProgress.csv
+        echo -n "N," >> "${METADIR}/summariseSampleProcessingProgress.csv"
     else
-        echo -n "Y," >> ${METADIR}/summariseSampleProcessingProgress.csv
+        echo -n "Y," >> "${METADIR}/summariseSampleProcessingProgress.csv"
     fi
     
-    if [ ! -s ${PEAKDIR}/${sampleName}.narrowPeak.filt ]
+    if [ ! -s "${PEAKDIR}/${sampleName}.narrowPeak.filt" ]
     then
-        echo "N" >> ${METADIR}/summariseSampleProcessingProgress.csv
+        echo "N" >> "${METADIR}/summariseSampleProcessingProgress.csv"
     else
-        echo "Y" >> ${METADIR}/summariseSampleProcessingProgress.csv
+        echo "Y" >> "${METADIR}/summariseSampleProcessingProgress.csv"
     fi
   
 done

--- a/sequencing/ChIPSeq/preprocessing/progressReport.sh
+++ b/sequencing/ChIPSeq/preprocessing/progressReport.sh
@@ -67,7 +67,7 @@ echo "Number of MACS2 peak files (paired end) found " $(ls ${PEAKDIR}/*.narrowPe
 ## save output in txt file
 echo "sampleID,dataFolder,R1Filename,R2Filename,FASTQCR1,FASTQCR2,FASTP,BOWTIE,filteredAligned,ENCODEMetrics,MACS2Peaks" > ${METADIR}/summariseSampleProcessingProgress.csv
 
-for sampleName in ${SAMPLEIDS[@]}
+for sampleName in "${SAMPLEIDS[@]}"
 do 
     toProcess=($(find ${RAWDATADIR} -maxdepth 1 -name ${sampleName}'*'))
     

--- a/sequencing/ChIPSeq/preprocessing/progressReport.sh
+++ b/sequencing/ChIPSeq/preprocessing/progressReport.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 ## searches for output files from each part of the QC pipeline and reports number of files found
 ## then searches specifically for each sample to identify what is missing
 


### PR DESCRIPTION
# Description

This pull request will make the s tests in ChIP/BS scripts hopefully more robust.

Previously there was a chance that certain samples had multiple matches for the glob patterns in the extended tests. For example, a sample might have both broad and narrow peaks. In such scenarios, the tests would break due to there being too many positional arguments.

## Caveats

I did not have any reference files for BSseq so I had to use WGBSeq files instead. As such it would be nice if the reviewer double checks to see if the following files are valid:

```bash
# I saw examples of these files in WGBS. Though BS might look slightly different?
${samplename}.fastqc.gz_trimming_report.txt
${sampleName}_1_val_1_bismark_bt2_pe.bam
${sampleName}.nodup.bismark.cov.gz

# This is the format of files in WGBS, but I couldn't find a single 
# instance of these files in ChIPSeq.
${FASTQCDIR}/${f2%%.*}_fastqc.zip
```

## Issue ticket number

This pull request is to address issue: #47.

## Type of pull request

- [ ] Bug fix
- [ ] New feature/enhancement
- [x] Code refactor
- [ ] Documentation update

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my code to check that it is functional
- [ ] I have used linters to check for common sources of errors
- [ ] I have implemented fail safes in my code to account for edge cases
- [ ] I have made the corresponding changes to the documentation
