### PR TITLE
fix: CountMTReads.txt now has tab separated values in header row

### DIFF
--- a/sequencing/ATACSeq/preprocessing/countMTReads.sh
+++ b/sequencing/ATACSeq/preprocessing/countMTReads.sh
@@ -17,7 +17,7 @@
 # ${ALIGNEDDIR}/countMTReads.txt
 
 
-echo "Filename\tMTReads\tAllMappedReads\n" > ${ALIGNEDDIR}/countMTReads.txt
+echo -e "Filename\tMTReads\tAllMappedReads" > ${ALIGNEDDIR}/countMTReads.txt
 
 for file in ${ALIGNEDDIR}/*_statsperchr.txt
 do 


### PR DESCRIPTION
# Description

This pull request will fix the escape sequences so that they are properly interpreted by `echo`.
It also removes the unnecessary `\n` escape sequence (which is automatically added).

## Issue ticket number

This pull request is to address issue: #157.

## Type of pull request

- [x] Bug fix
- [ ] New feature/enhancement
- [ ] Code refactor
- [ ] Documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code to check that it is functional
- [ ] I have used linters to check for common sources of errors
- [ ] I have implemented fail safes in my code to account for edge cases
- [ ] I have made the corresponding changes to the documentation
