### PR TITLE
Remove missing_package_linter

### DIFF
--- a/.github/linters/.lintr
+++ b/.github/linters/.lintr
@@ -4,6 +4,7 @@ linters: linters_with_tags(
     T_and_F_symbol_linter = NULL,
     implicit_integer_linter = NULL,
     undesirable_function_linter = NULL,
-    namespace_linter = NULL
+    namespace_linter = NULL,
+    missing_package_linter = NULL
   )
 


### PR DESCRIPTION
# Description

This pull request will remove `missing_package_linter` from the list of linters lintr uses. I'm removing this as we have separate scripts that are designed to install dependencies. lintr doesn't know this (even if it could, it would still raise this lint as its scope is limited to the files that you change in the PR). This linter is more useful when it is implemented into your own coding environment.

## Issue ticket number

This pull request is to address issue: #134.
