### PR TITLE
filter to columns that exist before subsetting

### DIFF
--- a/array/DNAm/preprocessing/calcQCMetrics.r
+++ b/array/DNAm/preprocessing/calcQCMetrics.r
@@ -448,7 +448,10 @@ if(length(cols) > 1){
 colnames(QCSum)[ncol(QCSum)]<-"passQCS2"
 rownames(QCSum)<-QCmetrics$Basename
 
-write.csv(cbind(QCmetrics[,c("Basename", "Sample_ID", "Individual_ID", "Cell_Type")], QCSum),  paste0(dataDir, "/2_gds/QCmetrics/PassQCStatusAllSamples.csv"))
+
+sampleColsToKeep<-c("Basename", "Sample_ID", "Individual_ID", "Cell_Type")
+sampleColsToKeep<-sampleColsToKeep[sampleColsToKeep %in% colnames(QCmetrics)]
+write.csv(cbind(QCmetrics[,sampleColsToKeep], QCSum),  paste0(dataDir, "/2_gds/QCmetrics/PassQCStatusAllSamples.csv"))
 
 
 #----------------------------------------------------------------------#


### PR DESCRIPTION
# Description

This pull request will filter to columns that exist in `QCmetrics` object before subsetting

## Issue ticket number 

This pull request is to address issue: #167 .

## Type of pull request

- [X ] Bug fix
- [ ] New feature/enhancement
- [ ] Code refactor
- [ ] Documentation update

## Checklist

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my code to check that it is functional
- [ ] I have used linters to check for common sources of errors
- [ ] I have implemented fail safes in my code to account for edge cases
- [ ] I have made the corresponding changes to the documentation
