### PR TITLE
fix: Enforce Boolean value for cellSorted

### DIFF
--- a/array/DNAm/config/config.example.r
+++ b/array/DNAm/config/config.example.r
@@ -3,7 +3,7 @@ projectTitle<-"MRC Schizophrenia FANS samples"
 processedBy<-"Complex Disease Epigenetic Group, University of Exeter Medical School"
 arrayVersion<-"Illumina EPIC microarray"
 tissueType<-"brain" # needs to be brain or blood to generate relevant cell composition estimates
-cellSorted<-"FALSE" # turns off cell type clustering check
+cellSorted<-FALSE # turns off cell type clustering check
 
 ## technical variables
 

--- a/array/DNAm/preprocessing/CETYGOdeconvolution.r
+++ b/array/DNAm/preprocessing/CETYGOdeconvolution.r
@@ -216,8 +216,11 @@ adultBloodCETYGO <- function(betas){
 # RUN CETYGO FUNCTION 
 #----------------------------------------------------------------------#
 
+cellSorted <- as.logical(cellSorted)
+if (is.na(cellSorted)) cellSorted <- FALSE
+
 # for sorted Brain tissue run on each cell type individually
-if(tissueType == "BRAIN" & cellSorted == "TRUE"){
+if(tissueType == "BRAIN" && cellSorted){
 
   for(cell in levels(sampleSheet$Cell_Type)){
       cellSampleSheet <- sampleSheet[which(sampleSheet$Cell_Type == cell),]
@@ -228,7 +231,7 @@ if(tissueType == "BRAIN" & cellSorted == "TRUE"){
   if(tissueType == "BLOOD"){
     adultBloodCETYGO(rawbetas)
   } else {
-    if(tissueType == "BRAIN" & cellSorted == "FALSE"){
+    if(tissueType == "BRAIN" && !cellSorted){
       adultBrainCETYGO(rawbetas, "bulk")
     }
   }

--- a/array/DNAm/preprocessing/clusterCellTypes.r
+++ b/array/DNAm/preprocessing/clusterCellTypes.r
@@ -36,7 +36,8 @@ arrayType <- toupper(arrayType)
 # STOP IF NOT REQUESTED TO RUN THIS SCRIPT
 #----------------------------------------------------------------------#
 
-if(!cellSorted){
+cellSorted <- as.logical(cellSorted)
+if(!cellSorted || is.na(cellSorted)){
 	quit(save = "no", status = 0)
 }
 


### PR DESCRIPTION
# Description

This pull request will correct the usage of `cellSorted` in:
- array/DNAm/preprocessing/clusterCellTypes.r
- array/DNAm/preprocessing/CETYGOdeconvolution.r

The scripts now enforce the variable to be a Boolean (via `as.logical`) and will treat the value as `FALSE` if a non truthy/falsy values is given (`as.logical` gives `NA`).

## Issue ticket number

This pull request is to address issue: #171 .

## Type of pull request

- [x] Bug fix
- [ ] New feature/enhancement
- [ ] Code refactor
- [ ] Documentation update

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my code to check that it is functional
- [x] I have used linters to check for common sources of errors
- [ ] I have implemented fail safes in my code to account for edge cases
- [ ] I have made the corresponding changes to the documentation
