### PR TITLE
feat: add stop call to error message in QC.rmd

### DIFF
--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -91,10 +91,19 @@ if(length(techVar) > 0){
 			}
 		}
       } else {
-        print(paste("Column", item, "not found. Please check config file.")) ### change to hard stop
-        #quit(save = "no")
+      column_not_found <- paste("Column", item, "not found.")
+      mismatched_column_error_message <- paste(
+	"Mismatched columns between sampleSheet and techVar.",
+	column_not_found,
+	"Please check that your config file and sampleSheet align.",
+	"techVar in config is set to:",
+	techVar,
+	"Column names of sampleSheet were read as:",
+	colnames(QCmetrics),
+	sep = "\n"
+      )
+      stop(mismatched_column_error_message)
       }
-    
   }
 }
 
@@ -125,10 +134,18 @@ if(length(bioVar) > 0){
 			}
 		}
       } else {
-        print(paste("Column", item, "not found. Please check config file.")) ### change to hard stop
-        #quit(save = "no")
-      }
-    
+      column_not_found <- paste("Column", item, "not found.")
+      mismatched_column_error_message <- paste(
+	"Mismatched columns between sampleSheet and techVar.",
+	column_not_found,
+	"Please check that your config file and sampleSheet align.",
+	"techVar in config is set to:",
+	techVar,
+	"Column names of sampleSheet were read as:",
+	colnames(QCmetrics),
+	sep = "\n"
+      )
+      stop(mismatched_column_error_message)
   }
 }
 

--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -146,6 +146,7 @@ if(length(bioVar) > 0){
 	sep = "\n"
       )
       stop(mismatched_column_error_message)
+    }
   }
 }
 


### PR DESCRIPTION
# Description

This pull request forcibly stops the creation of the QCmetrics report if columns are not identical between the config file and the sampleSheet.csv. The error message is now also updated such that it provides the necessary information to fix the issue in the error logs.

## Issue ticket number

This pull request is to address issue: #173 .

## Type of pull request

- [x] Bug fix
- [ ] New feature/enhancement
- [x] Code refactor
- [ ] Documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my code to check that it is functional
- [x] I have used linters to check for common sources of errors
- [x] I have implemented fail safes in my code to account for edge cases
- [ ] I have made the corresponding changes to the documentation
