### PR TITLE
refactor: convert section "definPlotParams" into functions

### DIFF
--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -93,15 +93,19 @@ is_wanted_column <- function(column_name, QCmetrics) {
   ))
 }
 
-define_plot_parameters <- function(QCmetrics, techVar, bioVar) {
-  potential_plot_columns <- c(techVar, bioVar)
+remove_unwanted_columns <- function(columns, QCmetrics) {
   columns_to_keep <- vapply(
-    potential_plot_columns,
+    columns,
     is_wanted_column,
     logical(1),
     QCmetrics
   )
-  plot_columns <- potential_plot_columns[columns_to_keep]
+  return(columns[columns_to_keep])
+}
+
+define_plot_parameters <- function(QCmetrics, techVar, bioVar) {
+  potential_plot_columns <- c(techVar, bioVar)
+  plot_columns <- remove_unwanted_columns(potential_plot_columns)
 
   plotCols<-data.frame("Basename" = QCmetrics[["Basename"]])
   legendParams<-list()
@@ -175,6 +179,7 @@ send_removal_message <- function(column_name, QCmetrics) {
   }
 }
 
+techVar <- remove_unwanted_columns(techVar, QCmetrics)
 for(item in techVar){
   tabTemp<-as.data.frame(table(QCmetrics[,item]))
   if(nrow(tabTemp) < 2){
@@ -191,6 +196,7 @@ These are only included if they are categorical. For this study the following bi
 
 ```{r bioVarSpecification, echo = FALSE, results = "asis", echo = FALSE}
 
+bioVar <- remove_unwanted_columns(bioVar, QCmetrics)
 for(item in bioVar){
 	pander(as.data.frame(table(QCmetrics[,item])), caption = paste("Summary of samples categorised by", item), col.names = c("Variable", "Number of Samples"))
 }

--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -94,7 +94,6 @@ is_wanted_column <- function(column_name, QCmetrics) {
 }
 
 update_plotCols <- function(column_name, QCmetrics, plotCols) {
-  # Rainbow requires a factor vector
   column <- parse_column(column_name, QCmetrics)
   unique_variables <- length(unique(column))
   colVar<-rainbow(unique_variables)[column]

--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -113,13 +113,13 @@ define_plot_parameters <- function(QCmetrics, techVar, bioVar) {
   for (column_name in plot_columns) {
     column <- parse_column(column_name, QCmetrics)
     unique_variables <- length(unique(column))
-    colVar <- rainbow(unique_variables)[column]
+    colours <- rainbow(unique_variables)[column]
 
     legendParams[[column_name]] <- cbind(
       levels(column),
       rainbow(unique_variables)
     )
-    plotCols[[column_name]] <- colVar
+    plotCols[[column_name]] <- colours
   }
   return(list(plotCols, legendParams))
 }

--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -107,8 +107,8 @@ define_plot_parameters <- function(QCmetrics, techVar, bioVar) {
   potential_plot_columns <- c(techVar, bioVar)
   plot_columns <- remove_unwanted_columns(potential_plot_columns, QCmetrics)
 
-  plotCols<-data.frame("Basename" = QCmetrics[["Basename"]])
-  legendParams<-list()
+  plotCols <- data.frame("Basename" = QCmetrics[["Basename"]])
+  legendParams <- list()
 
   for (column_name in plot_columns) {
     column <- parse_column(column_name, QCmetrics)

--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -131,7 +131,7 @@ define_plot_parameters <- function(QCmetrics, techVar, bioVar) {
 
 if (!exists("techVar")) techVar <- NULL
 if (!exists("bioVar")) bioVar <- NULL
-plot_paramaters <- define_plot_parameters(QCmetrics, techVar, bioVar)
+plot_parameters <- define_plot_parameters(QCmetrics, techVar, bioVar)
 plotCols <- plot_parameters[[1]]
 legendParams <- plot_parameters[[2]]
 ```

--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -166,12 +166,15 @@ send_removal_message <- function(column_name, QCmetrics) {
 
   if (all(is.na(column))) {
     removal_message(column_name, "all values were labelled as missing")
+    return()
   }
   if (length(unique(column)) == 1L) {
     removal_message(column_name, "all values were equivalent")
+    return()
   }
   if (anyDuplicated(column) == 0L) {
     removal_message(column_name, "all values were distinct")
+    return()
   }
 }
 

--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -119,11 +119,7 @@ define_plot_parameters <- function(QCmetrics, techVar, bioVar) {
       levels(column),
       rainbow(unique_variables)
     )
-    plotCols[[column_name]] <- data.frame(
-      plotCols,
-      colVar,
-      stringsAsFactors = FALSE
-    )
+    plotCols[[column_name]] <- colVar
   }
   return(list(plotCols, legendParams))
 }

--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -93,34 +93,6 @@ is_wanted_column <- function(column_name, QCmetrics) {
   return(TRUE)
 }
 
-update_plotCols <- function(column_name, QCmetrics, plotCols) {
-  column <- parse_column(column_name, QCmetrics)
-  unique_variables <- length(unique(column))
-  colVar<-rainbow(unique_variables)[column]
-
-  plotCols[[column_name]] <- data.frame(
-    plotCols,
-    colVar,
-    stringsAsFactors = FALSE
-  )
-
-  return(plotCols)
-}
-
-update_legendParams <- function(column_name, QCmetrics, legendParams) {
-  column <- parse_column(column_name, QCmetrics)
-  unique_variables <- length(unique(column))
-  colVar <- rainbow(unique_variables)[column]
-
-  legendParams[[column_name]] <- cbind(
-    levels(column),
-    rainbow(unique_variables)
-  )
-
-  return(legendParams)
-}
-
-
 define_plot_parameters <- function(QCmetrics, techVar, bioVar) {
   potential_plot_columns <- c(techVar, bioVar)
   columns_to_keep <- vapply(
@@ -133,9 +105,21 @@ define_plot_parameters <- function(QCmetrics, techVar, bioVar) {
 
   plotCols<-data.frame("Basename" = QCmetrics[["Basename"]])
   legendParams<-list()
+
   for (column_name in plot_columns) {
-    plotCols <- update_plotCols(column_name, QCmetrics, plotCols)
-    legendParams <- update_legendParams(column_name, QCmetrics, legendParams)
+    column <- parse_column(column_name, QCmetrics)
+    unique_variables <- length(unique(column))
+    colVar <- rainbow(unique_variables)[column]
+
+    legendParams[[column_name]] <- cbind(
+      levels(column),
+      rainbow(unique_variables)
+    )
+    plotCols[[column_name]] <- data.frame(
+      plotCols,
+      colVar,
+      stringsAsFactors = FALSE
+    )
   }
   return(list(plotCols, legendParams))
 }

--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -180,22 +180,33 @@ Data was loaded for `r nrow(QCmetrics)` samples from `r length(unique(QCmetrics$
 These are only included if they are categorical. For this study the following technical variables were included:
 
 ```{r techVarSpecification, results = "asis", echo = FALSE}
+send_removal_message <- function(column_name, QCmetrics) {
+  column <- parse_column(column_name, QCmetrics)
+
+  removal_message <- function(reason, column_name) {
+    message("Column ", column_name, " was excluded because ", reason,
+      ". Associated plots would give no useful information.")
+  }
+
+  if (all(is.na(column))) {
+    removal_message("all values were labelled as missing", column_name)
+  }
+  if (length(unique(column)) == 1L) {
+    removal_message("all values were equivalent", column_name)
+  }
+  if (anyDuplicated(column) == 0L) {
+    removal_message("all values were distinct", column_name)
+  }
+}
+
 for(item in techVar){
   tabTemp<-as.data.frame(table(QCmetrics[,item]))
   if(nrow(tabTemp) < 2){
   	pander(t(tabTemp), caption = paste("Summary of samples categorised by", item), row.names = c("Variable", "Number of Samples"))
   }
 }
-if(length(uniqueVar[uniqueVar %in% techVar]) > 0){
-	for(item in uniqueVar[uniqueVar %in% techVar]){
-		print(paste("The variable", item, "was excluded as all entries were unique."))
-	}
-}
-if(length(missingVar[missingVar %in% techVar]) > 0){
-	for(item in missingVar[missingVar %in% techVar]){
-		print(paste("The variable", item, "was excluded as all entries were unique."))
-	}
-}
+
+for (column_name in techVar) send_removal_message(column_name, QCmetrics)
 ```
 
 ## Summary of Biological Variables
@@ -207,16 +218,8 @@ These are only included if they are categorical. For this study the following bi
 for(item in bioVar){
 	pander(as.data.frame(table(QCmetrics[,item])), caption = paste("Summary of samples categorised by", item), col.names = c("Variable", "Number of Samples"))
 }
-if(length(uniqueVar[uniqueVar %in% bioVar]) > 0){
-	for(item in uniqueVar[uniqueVar %in% bioVar]){
-		print(paste("The variable", item, "was excluded as all entries were unique."))
-	}
-}
-if(length(missingVar[missingVar %in% bioVar]) > 0){
-	for(item in missingVar[missingVar %in% bioVar]){
-		print(paste("The variable", item, "was excluded as all entries were unique."))
-	}
-}
+
+for (column_name in bioVar) send_removal_message(column_name, QCmetrics)
 ```
 
 # Quality Control: Data Quality

--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -86,9 +86,33 @@ is_wanted_column <- function(column_name, QCmetrics) {
   # or more levels. We remove these columns from the plot to avoid errors.
   column <- parse_column(column_name, QCmetrics)
 
-  if (all(is.na(column))) return(FALSE)
-  if (length(unique(column)) == 1L) return(FALSE)
-  if (anyDuplicated(column) == 0L) return(FALSE)
+  if (all(is.na(column))) {
+    message(
+      "Column ",
+      column_name,
+      " has been removed from plots as all values are labelled as missing."
+    )
+    return(FALSE)
+  }
+  if (length(unique(column)) == 1L) {
+    message(
+      "Column ",
+      column_name,
+      " has been removed from plots as all values are equivalent. ",
+      "As such, the plot for this column would give no useful information."
+    )
+    return(FALSE)
+  }
+  if (anyDuplicated(column) == 0L) {
+    message(
+      "Column ",
+      column_name,
+      " has been removed from plots as all values are distinct. ",
+      "As such, the plot for this column would give no useful information ",
+      "(there would likely be too many colours to reasonably interpret)"
+    )
+   return(FALSE)
+  }
 
   return(TRUE)
 }

--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -45,6 +45,11 @@ nSamIP<-sum(QCmetrics$intensPASS)
 
 par(mar = c(4,4,1,1))
 
+# When in a loop, pander() calls do not render. This option always allows these
+# calls to be rendered in the resultant html file. No, wrapping pander() calls
+# in a print() function does not work (well, not how we want them to at least).
+panderOptions('knitr.auto.asis', FALSE)
+
 ```
 
 

--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -61,7 +61,7 @@ QCmetrics<-cbind(QCmetrics,QCSum[,c("passQCS1", "passQCS2")])
 ### define plotting parameters to automate which factors output is to be
 ### coloured by. These variables are provided in config file
 
-parse_column <- function(column_name, data) {
+parse_column <- function(column_name, QCmetrics) {
   # plotCols and rainbow() require factors
   column <- as.factor(QCmetrics[[column_name]])
   column[column == ""] <- NA

--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -163,19 +163,19 @@ These are only included if they are categorical. For this study the following te
 send_removal_message <- function(column_name, QCmetrics) {
   column <- parse_column(column_name, QCmetrics)
 
-  removal_message <- function(reason, column_name) {
+  removal_message <- function(column_name, reason) {
     message("Column ", column_name, " was excluded because ", reason,
       ". Associated plots would give no useful information.")
   }
 
   if (all(is.na(column))) {
-    removal_message("all values were labelled as missing", column_name)
+    removal_message(column_name, "all values were labelled as missing")
   }
   if (length(unique(column)) == 1L) {
-    removal_message("all values were equivalent", column_name)
+    removal_message(column_name, "all values were equivalent")
   }
   if (anyDuplicated(column) == 0L) {
-    removal_message("all values were distinct", column_name)
+    removal_message(column_name, "all values were distinct")
   }
 }
 

--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -58,104 +58,94 @@ QCmetrics<-cbind(QCmetrics,QCSum[,c("passQCS1", "passQCS2")])
 
 
 ```{r definPlotParams, include = FALSE}
-### define plotting parameters to automate which factors output is to be coloured by
-### These variables are provided in config file
+### define plotting parameters to automate which factors output is to be
+### coloured by. These variables are provided in config file
 
-plotCols<-data.frame("Basename" = QCmetrics$Basename)
-legendParams<-list()
+parse_column <- function(column_name, data) {
+  # plotCols and rainbow() require factors
+  column <- as.factor(QCmetrics[[column_name]])
+  column[column == ""] <- NA
+  return(column)
+}
 
-uniqueVar<-c()
-missingVar<-c()
-
-if(length(techVar) > 0){
-  for(item in techVar){
-    ### check if exists in QC metircs
-      if(item %in% colnames(QCmetrics)){
-        QCmetrics[which(QCmetrics[,item] == ""),item]<-NA
-        if(class(QCmetrics[,item]) != "factor"){
-          print(paste("Converting technical variable", item, "to factor."))
-          tmpVar<-as.factor(QCmetrics[,item])
-        } else {
-          tmpVar<-QCmetrics[,item]
-        }
-        numVar<-length(levels(tmpVar))
-        if(numVar == nrow(QCmetrics)){
-          uniqueVar<-c(uniqueVar, item)
-        } else {
-			if(sum(is.na(tmpVar)) == length(tmpVar)){
-				missingVar<-c(missingVar,item)
-			} else {
-				colVar<-rainbow(numVar)[tmpVar] ### convert to colours for plotting purposes
-				plotCols<-data.frame(plotCols, colVar, stringsAsFactors = FALSE)
-				legendParams[[item]]<-cbind(levels(tmpVar),rainbow(numVar))
-			}
-		}
-      } else {
-      column_not_found <- paste("Column", item, "not found.")
+is_wanted_column <- function(column_name, QCmetrics) {
+  if (! column_name %in% colnames(QCmetrics)) {
+      column_not_found <- paste("Column", column_name, "not found.")
       mismatched_column_error_message <- paste(
-	"Mismatched columns between sampleSheet and techVar.",
+	"Mismatched columns between sampleSheet and config:",
 	column_not_found,
 	"Please check that your config file and sampleSheet align.",
-	"techVar in config is set to:",
-	techVar,
 	"Column names of sampleSheet were read as:",
 	colnames(QCmetrics),
 	sep = "\n"
       )
       stop(mismatched_column_error_message)
-      }
   }
+
+  # Later, the contrasts function is used, which requires the column to have 2
+  # or more levels. We remove these columns from the plot to avoid errors.
+  column <- parse_column(column_name, QCmetrics)
+
+  if (all(is.na(column))) return(FALSE)
+  if (length(unique(column)) == 1L) return(FALSE)
+  if (anyDuplicated(column) == 0L) return(FALSE)
+
+  return(TRUE)
 }
 
-### remove from techVar 
-techVar<-techVar[!techVar %in% c(uniqueVar, missingVar)]
+update_plotCols <- function(column_name, QCmetrics, plotCols) {
+  # Rainbow requires a factor vector
+  column <- parse_column(column_name, QCmetrics)
+  unique_variables <- length(unique(column))
+  colVar<-rainbow(unique_variables)[column]
 
-if(length(bioVar) > 0){
-  for(item in bioVar){
-    ### check if exists in QC metircs
-      if(item %in% colnames(QCmetrics)){
-       QCmetrics[which(QCmetrics[,item] == ""),item]<-NA
-        if(class(QCmetrics[,item]) != "factor"){
-          print(paste("Converting biological variable", item, "to factor."))
-          tmpVar<-as.factor(QCmetrics[,item])
-        } else {
-          tmpVar<-QCmetrics[,item]
-        }
-        numVar<-length(levels(tmpVar))
-        if(numVar == nrow(QCmetrics)){
-          uniqueVar<-c(uniqueVar, item)
-        } else {
-			if(sum(is.na(tmpVar)) == length(tmpVar)){
-				missingVar<-c(missingVar,item)
-			} else {
-				colVar<-rainbow(numVar)[tmpVar] ### convert to colours for plotting purposes
-				plotCols<-data.frame(plotCols, colVar, stringsAsFactors = FALSE)
-				legendParams[[item]]<-cbind(levels(tmpVar),rainbow(numVar))
-			}
-		}
-      } else {
-      column_not_found <- paste("Column", item, "not found.")
-      mismatched_column_error_message <- paste(
-	"Mismatched columns between sampleSheet and techVar.",
-	column_not_found,
-	"Please check that your config file and sampleSheet align.",
-	"techVar in config is set to:",
-	techVar,
-	"Column names of sampleSheet were read as:",
-	colnames(QCmetrics),
-	sep = "\n"
-      )
-      stop(mismatched_column_error_message)
-    }
+  plotCols[[column_name]] <- data.frame(
+    plotCols,
+    colVar,
+    stringsAsFactors = FALSE
+  )
+
+  return(plotCols)
+}
+
+update_legendParams <- function(column_name, QCmetrics, legendParams) {
+  column <- parse_column(column_name, QCmetrics)
+  unique_variables <- length(unique(column))
+  colVar <- rainbow(unique_variables)[column]
+
+  legendParams[[column_name]] <- cbind(
+    levels(column),
+    rainbow(unique_variables)
+  )
+
+  return(legendParams)
+}
+
+
+define_plot_parameters <- function(QCmetrics, techVar, bioVar) {
+  potential_plot_columns <- c(techVar, bioVar)
+  columns_to_keep <- sapply(
+    potential_plot_columns,
+    is_wanted_column,
+    QCmetrics
+  )
+  plot_columns <- potential_plot_columns[columns_to_keep]
+
+  plotCols<-data.frame("Basename" = QCmetrics[["Basename"]])
+  legendParams<-list()
+  for (column_name in plot_columns) {
+    plotCols <- update_plotCols(column_name, QCmetrics, plotCols)
+    legendParams <- update_legendParams(column_name, QCmetrics, legendParams)
   }
+  return(list(plotCols, legendParams))
 }
 
-### remove from bioVar 
-bioVar<-bioVar[!bioVar %in% c(uniqueVar, missingVar)]
-if(ncol(plotCols) > 1){
-	colnames(plotCols)<-c("Basename", techVar, bioVar)
-}
 
+if (!exists("techVar")) techVar <- NULL
+if (!exists("bioVar")) bioVar <- NULL
+plot_paramaters <- define_plot_parameters(QCmetrics, techVar, bioVar)
+plotCols <- plot_parameters[[1]]
+legendParams <- plot_parameters[[2]]
 ```
 
 # Study Information

--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -183,7 +183,11 @@ techVar <- remove_unwanted_columns(techVar, QCmetrics)
 for(item in techVar){
   tabTemp<-as.data.frame(table(QCmetrics[,item]))
   if(nrow(tabTemp) < 2){
-  	pander(t(tabTemp), caption = paste("Summary of samples categorised by", item), row.names = c("Variable", "Number of Samples"))
+    pander(
+      t(tabTemp),
+      caption = paste("Summary of samples categorised by", item),
+      row.names = c("Variable", "Number of Samples")
+    )
   }
 }
 
@@ -198,7 +202,11 @@ These are only included if they are categorical. For this study the following bi
 
 bioVar <- remove_unwanted_columns(bioVar, QCmetrics)
 for(item in bioVar){
-	pander(as.data.frame(table(QCmetrics[,item])), caption = paste("Summary of samples categorised by", item), col.names = c("Variable", "Number of Samples"))
+  pander(
+    as.data.frame(table(QCmetrics[, item])),
+    caption = paste("Summary of samples categorised by", item),
+    col.names = c("Variable", "Number of Samples")
+  )
 }
 
 for (column_name in bioVar) send_removal_message(column_name, QCmetrics)

--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -91,10 +91,19 @@ if(length(techVar) > 0){
 			}
 		}
       } else {
-        print(paste("Column", item, "not found. Please check config file.")) ### change to hard stop
-        #quit(save = "no")
+      column_not_found <- paste("Column", item, "not found.")
+      mismatched_column_error_message <- paste(
+	"Mismatched columns between sampleSheet and techVar.",
+	column_not_found,
+	"Please check that your config file and sampleSheet align.",
+	"techVar in config is set to:",
+	techVar,
+	"Column names of sampleSheet were read as:",
+	colnames(QCmetrics),
+	sep = "\n"
+      )
+      stop(mismatched_column_error_message)
       }
-    
   }
 }
 
@@ -125,10 +134,19 @@ if(length(bioVar) > 0){
 			}
 		}
       } else {
-        print(paste("Column", item, "not found. Please check config file.")) ### change to hard stop
-        #quit(save = "no")
-      }
-    
+      column_not_found <- paste("Column", item, "not found.")
+      mismatched_column_error_message <- paste(
+	"Mismatched columns between sampleSheet and techVar.",
+	column_not_found,
+	"Please check that your config file and sampleSheet align.",
+	"techVar in config is set to:",
+	techVar,
+	"Column names of sampleSheet were read as:",
+	colnames(QCmetrics),
+	sep = "\n"
+      )
+      stop(mismatched_column_error_message)
+    }
   }
 }
 

--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -175,6 +175,8 @@ send_removal_message <- function(column_name, QCmetrics) {
   }
 }
 
+for (column_name in techVar) send_removal_message(column_name, QCmetrics)
+
 techVar <- remove_unwanted_columns(techVar, QCmetrics)
 for(item in techVar){
   tabTemp<-as.data.frame(table(QCmetrics[,item]))
@@ -186,8 +188,6 @@ for(item in techVar){
     )
   }
 }
-
-for (column_name in techVar) send_removal_message(column_name, QCmetrics)
 ```
 
 ## Summary of Biological Variables
@@ -195,6 +195,8 @@ for (column_name in techVar) send_removal_message(column_name, QCmetrics)
 These are only included if they are categorical. For this study the following biological variables were included:
 
 ```{r bioVarSpecification, echo = FALSE, results = "asis", echo = FALSE}
+
+for (column_name in bioVar) send_removal_message(column_name, QCmetrics)
 
 bioVar <- remove_unwanted_columns(bioVar, QCmetrics)
 for(item in bioVar){
@@ -204,8 +206,6 @@ for(item in bioVar){
     col.names = c("Variable", "Number of Samples")
   )
 }
-
-for (column_name in bioVar) send_removal_message(column_name, QCmetrics)
 ```
 
 # Quality Control: Data Quality

--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -105,7 +105,7 @@ remove_unwanted_columns <- function(columns, QCmetrics) {
 
 define_plot_parameters <- function(QCmetrics, techVar, bioVar) {
   potential_plot_columns <- c(techVar, bioVar)
-  plot_columns <- remove_unwanted_columns(potential_plot_columns)
+  plot_columns <- remove_unwanted_columns(potential_plot_columns, QCmetrics)
 
   plotCols<-data.frame("Basename" = QCmetrics[["Basename"]])
   legendParams<-list()

--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -86,35 +86,11 @@ is_wanted_column <- function(column_name, QCmetrics) {
   # or more levels. We remove these columns from the plot to avoid errors.
   column <- parse_column(column_name, QCmetrics)
 
-  if (all(is.na(column))) {
-    message(
-      "Column ",
-      column_name,
-      " has been removed from plots as all values are labelled as missing."
-    )
-    return(FALSE)
-  }
-  if (length(unique(column)) == 1L) {
-    message(
-      "Column ",
-      column_name,
-      " has been removed from plots as all values are equivalent. ",
-      "As such, the plot for this column would give no useful information."
-    )
-    return(FALSE)
-  }
-  if (anyDuplicated(column) == 0L) {
-    message(
-      "Column ",
-      column_name,
-      " has been removed from plots as all values are distinct. ",
-      "As such, the plot for this column would give no useful information ",
-      "(there would likely be too many colours to reasonably interpret)"
-    )
-   return(FALSE)
-  }
-
-  return(TRUE)
+  return(!(
+    all(is.na(column)) ||
+    length(unique(column)) == 1L ||
+    anyDuplicated(column) == 0L
+  ))
 }
 
 define_plot_parameters <- function(QCmetrics, techVar, bioVar) {

--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -123,9 +123,10 @@ update_legendParams <- function(column_name, QCmetrics, legendParams) {
 
 define_plot_parameters <- function(QCmetrics, techVar, bioVar) {
   potential_plot_columns <- c(techVar, bioVar)
-  columns_to_keep <- sapply(
+  columns_to_keep <- vapply(
     potential_plot_columns,
     is_wanted_column,
+    logical(1),
     QCmetrics
   )
   plot_columns <- potential_plot_columns[columns_to_keep]


### PR DESCRIPTION
# Description

This pull request:

- Forcibly stops the creation of the QCmetrics report if columns are not identical between the config file and the sampleSheet.csv. The error message is now also updated such that it provides the necessary information to fix the issue in the error logs.
- Correctly identifies columns that should not be brought forward into the later plots 
  - Which include:
    - Columns with all missing values
    - Columns with only a single unique value (`contrasts()` will fail in this case)
    - Columns that contain all unique values (not sure why this is the case, but the old code did this)
- Refactors the definPlotParams section to use functions and less repeated code

## Issue ticket number

This pull request is to address issues: #173 #177 (maybe #33 ?).

## Type of pull request

- [x] Bug fix
- [ ] New feature/enhancement
- [x] Code refactor
- [ ] Documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my code to check that it is functional
- [x] I have used linters to check for common sources of errors
- [x] I have implemented fail safes in my code to account for edge cases
- [ ] I have made the corresponding changes to the documentation
