### PR TITLE
fix: Assign NA values instead of filtering snpCor 

### DIFF
--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -856,7 +856,7 @@ Having excluding poor quality data and sample swaps we will repeat the genetic c
 
 ```{r,findDuplicateSamplesPostQC, echo = FALSE}
 
-passQC<-QCSum[["Basename"]][as.logical(QCSum[,"passQCS2"])]
+passQC <- QCSum[["Basename"]][as.logical(QCSum[, "passQCS2"])]
 
 # samples that do not pass QC should be ignored, but not removed as snpCor 
 # needs to remain the same size as QCmetrics (for data manipulation)
@@ -869,17 +869,22 @@ snpCor.tmp <- snpCor
 diag(snpCor.temp) <- NA
 max_correlation <- max(snpCor.tmp, na.rm = TRUE)
 
-if(max_correlation > 0.8){
+if(max_correlation > 0.8) {
   # pull out samples that are genetically identical
-  predictedduplicates<-vector(length = ncol(snpCor))
+  predictedduplicates <- vector(length = ncol(snpCor))
   for(i in seq_len(ncol(snpCor))) {
-    predictedduplicates[i]<-paste(sort(names(which(snpCor[,i] > 0.8))), sep = "|", collapse = "|")
+    predictedduplicates[i] <- paste(
+      sort(names(which(snpCor[, i] > 0.8))),
+      sep = "|",
+      collapse = "|"
+    )
   }
 } else {
-  predictedduplicates<-colnames(snpCor)
+  predictedduplicates <- colnames(snpCor)
 } 
 
-QCmetrics[["predictedduplicates"]]<-predictedduplicates
+QCmetrics[["predictedduplicates"]] <- predictedduplicates
+
 # predicteddupliactes will be "" for samples that have been removed (or just
 # SAMPLE_NAME if max_correlation <= 0.8). We want the predictedduplicates 
 # column to be NA for samples that did not pass QC.

--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -858,9 +858,18 @@ Having excluding poor quality data and sample swaps we will repeat the genetic c
 
 passQC<-QCSum$Basename[as.logical(QCSum[,"passQCS2"])]
 
-snpCor<-snpCor[passQC, passQC]
+# samples that do not pass QC should be ignored, but not removed as snpCor 
+# needs to remain the same size as QCmetrics (for data manipulation)
+snpCor[!passQC, ] <- NA
+snpCor[, !passQC] <- NA
 
-if(max(snpCor, na.rm = TRUE) > 0.8){
+# The Diagonal of correlation matrix is always ones. We remove these for a 
+# potential speed up (in the event that no snps are highly correlated)
+snpCor.tmp <- snpCor
+diag(snpCor.temp) <- NA
+max_correlation <- max(snpCor.tmp, na.rm = TRUE)
+
+if(max_correlation > 0.8){
   	# pull out samples that are genetically identical
   	predictedduplicates<-vector(length = ncol(snpCor))
   	for(i in 1:ncol(snpCor)){
@@ -870,7 +879,8 @@ if(max(snpCor, na.rm = TRUE) > 0.8){
 	  predictedduplicates<-colnames(snpCor)
 	} 
 
-  QCmetrics$predictedduplicates<-predictedduplicates
+QCmetrics$predictedduplicates<-predictedduplicates
+QCmetrics[["predictedduplicates"]][QCmetrics[["Basename"]] != passQC] <- NA
 
 ```
 

--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -876,8 +876,7 @@ passQC <- QCSum[["Basename"]][as.logical(QCSum[, "passQCS2"])]
 
 # samples that do not pass QC should be ignored, but not removed as snpCor 
 # needs to remain the same size as QCmetrics (for data manipulation)
-snpCor[!passQC, ] <- NA
-snpCor[, !passQC] <- NA
+snpCor[!passQC] <- NA
 
 predictedduplicates <- findDuplicateSamples(snpCor)
 QCmetrics[["predictedduplicates"]] <- predictedduplicates

--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -872,7 +872,7 @@ max_correlation <- max(snpCor.tmp, na.rm = TRUE)
 if(max_correlation > 0.8){
   # pull out samples that are genetically identical
   predictedduplicates<-vector(length = ncol(snpCor))
-  for(i in 1:ncol(snpCor)){
+  for(i in seq_len(ncol(snpCor))) {
     predictedduplicates[i]<-paste(sort(names(which(snpCor[,i] > 0.8))), sep = "|", collapse = "|")
   }
 } else {

--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -856,7 +856,7 @@ Having excluding poor quality data and sample swaps we will repeat the genetic c
 
 ```{r,findDuplicateSamplesPostQC, echo = FALSE}
 
-passQC<-QCSum$Basename[as.logical(QCSum[,"passQCS2"])]
+passQC<-QCSum[["Basename"]][as.logical(QCSum[,"passQCS2"])]
 
 # samples that do not pass QC should be ignored, but not removed as snpCor 
 # needs to remain the same size as QCmetrics (for data manipulation)
@@ -879,7 +879,7 @@ if(max_correlation > 0.8){
   predictedduplicates<-colnames(snpCor)
 } 
 
-QCmetrics$predictedduplicates<-predictedduplicates
+QCmetrics[["predictedduplicates"]]<-predictedduplicates
 QCmetrics[["predictedduplicates"]][QCmetrics[["Basename"]] != passQC] <- NA
 
 ```

--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -872,7 +872,7 @@ Having excluding poor quality data and sample swaps we will repeat the genetic c
 
 ```{r,findDuplicateSamplesPostQC, echo = FALSE}
 
-passQC <- QCSum[["Basename"]][as.logical(QCSum[, "passQCS2"])]
+passQC <- as.logical(QCSum[, "passQCS2"])
 
 # samples that do not pass QC should be ignored, but not removed as snpCor 
 # needs to remain the same size as QCmetrics (for data manipulation)
@@ -884,7 +884,7 @@ QCmetrics[["predictedduplicates"]] <- predictedduplicates
 # predicteddupliactes will be "" for samples that have been removed (or just
 # SAMPLE_NAME if max_correlation <= 0.8). We want the predictedduplicates 
 # column to be NA for samples that did not pass QC.
-QCmetrics[["predictedduplicates"]][QCmetrics[["Basename"]] != passQC] <- NA
+QCmetrics[["predictedduplicates"]][!passQC] <- NA
 
 ```
 
@@ -942,7 +942,7 @@ Checking if genetically identical samples have the sample Individual ID:
 Checking if samples with same Individual ID are genetically identical:
 
 ```{r checkGenoSampleswithSameIDPostQC, echo = FALSE}
-
+passQC <- QCSum[["Basename"]][as.logical(QCSum[, "passQCS2"])]
 QCmetrics<-QCmetrics[match(passQC, QCmetrics$Basename),]
 
 ### check if samples with same Individual ID are genetically identical.

--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -513,7 +513,7 @@ abline(v = 0.8, col = "red")
 
 ```{r,findDuplicateSamples, echo = FALSE}
 findDuplicateSamples <- function(snpCor) {
-  # The diagonal of a correlation matrix is always ones. We remove these for a 
+  # The diagonal of a correlation matrix is always ones. We ignore these for a 
   # potential speed up (in the event that no snps are highly correlated)
   snpCor.tmp <- snpCor
   diag(snpCor.temp) <- NA

--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -870,14 +870,14 @@ diag(snpCor.temp) <- NA
 max_correlation <- max(snpCor.tmp, na.rm = TRUE)
 
 if(max_correlation > 0.8){
-  	# pull out samples that are genetically identical
-  	predictedduplicates<-vector(length = ncol(snpCor))
-  	for(i in 1:ncol(snpCor)){
-  	  predictedduplicates[i]<-paste(sort(names(which(snpCor[,i] > 0.8))), sep = "|", collapse = "|")
-  	}
-  } else {
-	  predictedduplicates<-colnames(snpCor)
-	} 
+  # pull out samples that are genetically identical
+  predictedduplicates<-vector(length = ncol(snpCor))
+  for(i in 1:ncol(snpCor)){
+    predictedduplicates[i]<-paste(sort(names(which(snpCor[,i] > 0.8))), sep = "|", collapse = "|")
+  }
+} else {
+  predictedduplicates<-colnames(snpCor)
+} 
 
 QCmetrics$predictedduplicates<-predictedduplicates
 QCmetrics[["predictedduplicates"]][QCmetrics[["Basename"]] != passQC] <- NA

--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -512,16 +512,32 @@ abline(v = 0.8, col = "red")
 
 
 ```{r,findDuplicateSamples, echo = FALSE}
-  if(max(snpCor, na.rm = TRUE) > 0.8){
-  	# pull out samples that are genetically identical
-  	predictedduplicates<-vector(length = ncol(snpCor))
-  	for(i in 1:ncol(snpCor)){
-  	  predictedduplicates[i]<-paste(sort(c(colnames(snpCor)[i],names(which(snpCor[,i] > 0.8)))), sep = "|", collapse = "|")
-  	}
+findDuplicateSamples <- function(snpCor) {
+  # The diagonal of a correlation matrix is always ones. We remove these for a 
+  # potential speed up (in the event that no snps are highly correlated)
+  snpCor.tmp <- snpCor
+  diag(snpCor.temp) <- NA
+  max_correlation <- max(snpCor.tmp, na.rm = TRUE)
+
+  if(max_correlation > 0.8) {
+    # pull out samples that are genetically identical
+    predictedduplicates <- vector(length = ncol(snpCor))
+    for(i in seq_len(ncol(snpCor))) {
+      predictedduplicates[i] <- paste(
+	sort(names(which(snpCor[, i] > 0.8))),
+	sep = "|",
+	collapse = "|"
+      )
+    }
   } else {
-	  predictedduplicates<-colnames(snpCor)
-	} 
-	predictedduplicates[!QCmetrics$intensPASS]<-NA ## exclude things not with minimum intensity threshold
+    predictedduplicates <- colnames(snpCor)
+  } 
+  return(predictedduplicates)
+}
+
+predictedduplicates <- findDuplicateSamples(snpCor)
+# Exclude things not with minimum intensity threshold
+predictedduplicates[!QCmetrics$intensPASS]<-NA 
 ```
 
 We identified `r length(unique(predictedduplicates))` genetically unique individuals with the following distribution of number of samples per individual.
@@ -863,26 +879,7 @@ passQC <- QCSum[["Basename"]][as.logical(QCSum[, "passQCS2"])]
 snpCor[!passQC, ] <- NA
 snpCor[, !passQC] <- NA
 
-# The Diagonal of correlation matrix is always ones. We remove these for a 
-# potential speed up (in the event that no snps are highly correlated)
-snpCor.tmp <- snpCor
-diag(snpCor.temp) <- NA
-max_correlation <- max(snpCor.tmp, na.rm = TRUE)
-
-if(max_correlation > 0.8) {
-  # pull out samples that are genetically identical
-  predictedduplicates <- vector(length = ncol(snpCor))
-  for(i in seq_len(ncol(snpCor))) {
-    predictedduplicates[i] <- paste(
-      sort(names(which(snpCor[, i] > 0.8))),
-      sep = "|",
-      collapse = "|"
-    )
-  }
-} else {
-  predictedduplicates <- colnames(snpCor)
-} 
-
+predictedduplicates <- findDuplicateSamples(snpCor)
 QCmetrics[["predictedduplicates"]] <- predictedduplicates
 
 # predicteddupliactes will be "" for samples that have been removed (or just

--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -516,7 +516,7 @@ findDuplicateSamples <- function(snpCor) {
   # The diagonal of a correlation matrix is always ones. We ignore these for a 
   # potential speed up (in the event that no snps are highly correlated)
   snpCor.tmp <- snpCor
-  diag(snpCor.temp) <- NA
+  diag(snpCor.tmp) <- NA
   max_correlation <- max(snpCor.tmp, na.rm = TRUE)
 
   if(max_correlation > 0.8) {

--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -880,6 +880,9 @@ if(max_correlation > 0.8){
 } 
 
 QCmetrics[["predictedduplicates"]]<-predictedduplicates
+# predicteddupliactes will be "" for samples that have been removed (or just
+# SAMPLE_NAME if max_correlation <= 0.8). We want the predictedduplicates 
+# column to be NA for samples that did not pass QC.
 QCmetrics[["predictedduplicates"]][QCmetrics[["Basename"]] != passQC] <- NA
 
 ```


### PR DESCRIPTION
# Description

This pull request will attempt to fix the issues that come with having samples fail the QC. Before, if a sample failed QC, it was removed from snpCor. This causes problems as `predictedduplicates` can have less entries than `QCmetrics` has rows. The updated method ignores these samples, rather than remove them.

## Issue ticket number

This pull request is to address issue: #179.

## Type of pull request

- [x] Bug fix
- [ ] New feature/enhancement
- [x] Code refactor
- [ ] Documentation update

## Checklist

- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my code to check that it is functional
- [x] I have used linters to check for common sources of errors
- [ ] I have implemented fail safes in my code to account for edge cases
- [ ] I have made the corresponding changes to the documentation
