### PR TITLE
refactor: simplify conditional logic

### DIFF
--- a/array/DNAm/preprocessing/CETYGOdeconvolution.r
+++ b/array/DNAm/preprocessing/CETYGOdeconvolution.r
@@ -223,16 +223,15 @@ if (is.na(cellSorted)) cellSorted <- FALSE
 if(tissueType == "BRAIN" && cellSorted){
 
   for(cell in levels(sampleSheet$Cell_Type)){
-      cellSampleSheet <- sampleSheet[which(sampleSheet$Cell_Type == cell),]
-      cellBetas <- rawbetas[, colnames(rawbetas) %in% cellSampleSheet$Basename]
-      adultBrainCETYGO(cellBetas, cell)
+    cellSampleSheet <- sampleSheet[which(sampleSheet$Cell_Type == cell),]
+    cellBetas <- rawbetas[, colnames(rawbetas) %in% cellSampleSheet$Basename]
+    adultBrainCETYGO(cellBetas, cell)
   }
 } else {
   if(tissueType == "BLOOD"){
     adultBloodCETYGO(rawbetas)
-  } else {
-    if(tissueType == "BRAIN" && !cellSorted){
-      adultBrainCETYGO(rawbetas, "bulk")
-    }
+  }
+  if(tissueType == "BRAIN") {
+    adultBrainCETYGO(rawbetas, "bulk")
   }
 }


### PR DESCRIPTION
# Description
`cellSorted` is already necessarily false at this point in the conditional loop. `tissueType` cannot be both BLOOD and BRAIN, so the `else` keyword is not required.

## Issue ticket number

This pull request is to address issue: #186.

## Type of pull request

- [ ] Bug fix
- [ ] New feature/enhancement
- [x] Code refactor
- [ ] Documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my code to check that it is functional
- [x] I have used linters to check for common sources of errors
- [ ] I have implemented fail safes in my code to account for edge cases
- [ ] I have made the corresponding changes to the documentation
