### PR TITLE
revert snpCor diagonal to 1s to correctly identify unique individuals 

### DIFF
--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -514,11 +514,10 @@ This step uses the 59 SNP probes on the array to identify genetically identical 
 
 ```{r, duplicateSamples, echo = FALSE, fig.width = 8}
 
-for(i in 1:ncol(snpCor)){
-  snpCor[i,i]<-NA
-}
- hist(snpCor, breaks = seq(-1,1,0.05), xlab = "SNP correlation", main = "All samples", col = "gray")
+diag(snpCor)<-NA
+hist(snpCor, breaks = seq(-1,1,0.05), xlab = "SNP correlation", main = "All samples", col = "gray")
 abline(v = 0.8, col = "red")
+diag(snpCor)<-1
 
 
 ```


### PR DESCRIPTION
## Issue ticket number

This pull request is to address issue: #193.

## Type of pull request

- [X] Bug fix
- [ ] New feature/enhancement
- [ ] Code refactor
- [ ] Documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have tested my code to check that it is functional
- [ ] I have used linters to check for common sources of errors
- [ ] I have implemented fail safes in my code to account for edge cases
- [ ] I have made the corresponding changes to the documentation
