### PR TITLE
fix diagnostic plot case where no samples are genetically identical

### DIFF
--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -731,27 +731,29 @@ for(each in unique(sampleGroups$predictedduplicates)){
 		bsnames<-unlist(strsplit(as.character(each), "\\|"))
 		
 		par(mfrow = c(3,4))
+    ## where multiple samples classed as incorrectly genetically identical
 		## plot 59 snp probes against each other
-		for(i in 1:(length(bsnames)-1)){
-				if(QCmetrics[match(bsnames[i], QCmetrics$Basename), "passQCS1"]){
-			    xlabcol<-"black"
-			  }else{
-			    xlabcol<-"red"
-			  }
-		  for(j in (i+1):length(bsnames)){
-        if(QCmetrics[match(bsnames[j], QCmetrics$Basename), "passQCS1"]){
-			    ylabcol<-"black"
-			  }else{
-			    ylabcol<-"red"
-			  }
-			 plot(rsbetas[,bsnames[i]], rsbetas[,bsnames[j]], xlab = "",ylab = "", pch = 16, xlim = c(0,1), ylim = c(0,1))
-			 title(xlab = bsnames[i], col.lab = xlabcol)
-			 title(ylab = bsnames[j], col.lab = ylabcol)
-			}
+    if(length(bsnames) > 1){
+      for(i in 1:(length(bsnames)-1)){
+          if(QCmetrics[match(bsnames[i], QCmetrics$Basename), "passQCS1"]){
+            xlabcol<-"black"
+          }else{
+            xlabcol<-"red"
+          }
+        for(j in (i+1):length(bsnames)){
+          if(QCmetrics[match(bsnames[j], QCmetrics$Basename), "passQCS1"]){
+            ylabcol<-"black"
+          }else{
+            ylabcol<-"red"
+          }
+        plot(rsbetas[,bsnames[i]], rsbetas[,bsnames[j]], xlab = "",ylab = "", pch = 16, xlim = c(0,1), ylim = c(0,1))
+        title(xlab = bsnames[i], col.lab = xlabcol)
+        title(ylab = bsnames[j], col.lab = ylabcol)
+        }
+      }
 		}
-		
-
-		## plot against matched genetic data
+    
+		## plot against matched genetic data (if it exists)
 		allGenoIDs<-unique(sampleGroups$Genotype.IID[which(sampleGroups$predictedduplicates == each)])
 		allGenoIDs<-c(na.omit(allGenoIDs))
 		if(length(allGenoIDs) > 0){

--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -746,7 +746,15 @@ for(each in unique(sampleGroups$predictedduplicates)){
 	  }else{
 	    ylabcol<-"red"
 	  }
-	  plot(rsbetas[,bsnames[i]], rsbetas[,bsnames[j]], xlab = "",ylab = "", pch = 16, xlim = c(0,1), ylim = c(0,1))
+	  plot(
+	    rsbetas[,bsnames[i]],
+	    rsbetas[,bsnames[j]],
+	    xlab = "",
+	    ylab = "",
+	    pch = 16,
+	    xlim = c(0,1),
+	    ylim = c(0,1)
+	  )
 	  title(xlab = bsnames[i], col.lab = xlabcol)
 	  title(ylab = bsnames[j], col.lab = ylabcol)
 	}
@@ -764,8 +772,17 @@ for(each in unique(sampleGroups$predictedduplicates)){
 	  xlabcol<-"red"
 	}
 	methID<-sampleGroups$Individual_ID[match(bsnames[i], sampleGroups$barcode)]
-      for(j in 1:length(allGenoIDs)){
-	  plot(betas.rs[,bsnames[i]], geno.mat[match(allGenoIDs[j],rownames(geno.mat))[1],], pch = 16, xlab = "", ylab = allGenoIDs[j], main = methID, xlim = c(0,1), ylim = c(0,2))
+	for(j in 1:length(allGenoIDs)){
+	  plot(
+	    betas.rs[,bsnames[i]],
+	    geno.mat[match(allGenoIDs[j],rownames(geno.mat))[1],],
+	    pch = 16,
+	    xlab = "",
+	    ylab = allGenoIDs[j],
+	    main = methID,
+	    xlim = c(0,1),
+	    ylim = c(0,2)
+	  )
 	  title(xlab = bsnames[i], col.lab = xlabcol)
 	}
       }
@@ -775,17 +792,26 @@ for(each in unique(sampleGroups$predictedduplicates)){
 
 ## Plot instances where Individual ID says should be the same person
 for(each in unique(sampleGroups$Individual_ID)){
-		par(mfrow = c(3,4))
-    bsindexes <- sampleGroups$Basename[which(sampleGroups$Individual_ID == each)]
-    if(length(bsindexes) > 1){
-      for(i in 1:(length(bsindexes)-1)){
-        for(j in (i+1):length(bsindexes)){
-          plot(rsbetas[,bsindexes[i]], rsbetas[,bsindexes[j]], xlab = "",ylab = "", pch = 16, xlim = c(0,1), ylim = c(0,1), main = each)
-          title(xlab = bsindexes[i], col.lab = xlabcol)
-          title(ylab = bsindexes[j], col.lab = ylabcol)
-        }
+  par(mfrow = c(3,4))
+  bsindexes <- sampleGroups$Basename[which(sampleGroups$Individual_ID == each)]
+  if(length(bsindexes) > 1){
+    for(i in 1:(length(bsindexes)-1)){
+      for(j in (i+1):length(bsindexes)){
+	plot(
+	  rsbetas[,bsindexes[i]],
+	  rsbetas[,bsindexes[j]],
+	  xlab = "",
+	  ylab = "",
+	  pch = 16,
+	  xlim = c(0,1),
+	  ylim = c(0,1),
+	  main = each
+	)
+	title(xlab = bsindexes[i], col.lab = xlabcol)
+	title(ylab = bsindexes[j], col.lab = ylabcol)
       }
     }
+  }
 
 }
 

--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -726,51 +726,51 @@ if(length(errorIndexes) > 0){
 
 pdf(paste0(dataDir, "/2_gds/QCmetrics/PlotsWithinDNAmMismatches.pdf"), width = 10, height = 8)
 for(each in unique(sampleGroups$predictedduplicates)){
-	if(!is.na(each)){
+  if(!is.na(each)){
 
-		bsnames<-unlist(strsplit(as.character(each), "\\|"))
-		
-		par(mfrow = c(3,4))
+    bsnames<-unlist(strsplit(as.character(each), "\\|"))
+
+    par(mfrow = c(3,4))
     ## where multiple samples classed as incorrectly genetically identical
-		## plot 59 snp probes against each other
+    ## plot 59 snp probes against each other
     if(length(bsnames) > 1){
       for(i in 1:(length(bsnames)-1)){
-          if(QCmetrics[match(bsnames[i], QCmetrics$Basename), "passQCS1"]){
-            xlabcol<-"black"
-          }else{
-            xlabcol<-"red"
-          }
-        for(j in (i+1):length(bsnames)){
-          if(QCmetrics[match(bsnames[j], QCmetrics$Basename), "passQCS1"]){
-            ylabcol<-"black"
-          }else{
-            ylabcol<-"red"
-          }
-        plot(rsbetas[,bsnames[i]], rsbetas[,bsnames[j]], xlab = "",ylab = "", pch = 16, xlim = c(0,1), ylim = c(0,1))
-        title(xlab = bsnames[i], col.lab = xlabcol)
-        title(ylab = bsnames[j], col.lab = ylabcol)
-        }
-      }
-		}
-    
-		## plot against matched genetic data (if it exists)
-		allGenoIDs<-unique(sampleGroups$Genotype.IID[which(sampleGroups$predictedduplicates == each)])
-		allGenoIDs<-c(na.omit(allGenoIDs))
-		if(length(allGenoIDs) > 0){
-			for(i in 1:length(bsnames)){
-			  if(QCmetrics[match(bsnames[i], QCmetrics$Basename), "passQCS1"]){
-			    xlabcol<-"black"
-			  }else{
-			    xlabcol<-"red"
-			  }
-				methID<-sampleGroups$Individual_ID[match(bsnames[i], sampleGroups$barcode)]
-				for(j in 1:length(allGenoIDs)){
-					plot(betas.rs[,bsnames[i]], geno.mat[match(allGenoIDs[j],rownames(geno.mat))[1],], pch = 16, xlab = "", ylab = allGenoIDs[j], main = methID, xlim = c(0,1), ylim = c(0,2))
-				  title(xlab = bsnames[i], col.lab = xlabcol)
-				}
-			}
-		}
+	if(QCmetrics[match(bsnames[i], QCmetrics$Basename), "passQCS1"]){
+	  xlabcol<-"black"
+	}else{
+	  xlabcol<-"red"
 	}
+	for(j in (i+1):length(bsnames)){
+	  if(QCmetrics[match(bsnames[j], QCmetrics$Basename), "passQCS1"]){
+	    ylabcol<-"black"
+	  }else{
+	    ylabcol<-"red"
+	  }
+	  plot(rsbetas[,bsnames[i]], rsbetas[,bsnames[j]], xlab = "",ylab = "", pch = 16, xlim = c(0,1), ylim = c(0,1))
+	  title(xlab = bsnames[i], col.lab = xlabcol)
+	  title(ylab = bsnames[j], col.lab = ylabcol)
+	}
+      }
+    }
+
+    ## plot against matched genetic data (if it exists)
+    allGenoIDs<-unique(sampleGroups$Genotype.IID[which(sampleGroups$predictedduplicates == each)])
+    allGenoIDs<-c(na.omit(allGenoIDs))
+    if(length(allGenoIDs) > 0){
+      for(i in 1:length(bsnames)){
+	if(QCmetrics[match(bsnames[i], QCmetrics$Basename), "passQCS1"]){
+	  xlabcol<-"black"
+	}else{
+	  xlabcol<-"red"
+	}
+	methID<-sampleGroups$Individual_ID[match(bsnames[i], sampleGroups$barcode)]
+      for(j in 1:length(allGenoIDs)){
+	  plot(betas.rs[,bsnames[i]], geno.mat[match(allGenoIDs[j],rownames(geno.mat))[1],], pch = 16, xlab = "", ylab = allGenoIDs[j], main = methID, xlim = c(0,1), ylim = c(0,2))
+	  title(xlab = bsnames[i], col.lab = xlabcol)
+	}
+      }
+    }
+  }
 }
 
 ## Plot instances where Individual ID says should be the same person

--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -772,6 +772,23 @@ for(each in unique(sampleGroups$predictedduplicates)){
 		}
 	}
 }
+
+## Plot instances where Individual ID says should be the same person
+for(each in unique(sampleGroups$Individual_ID)){
+		par(mfrow = c(3,4))
+    bsindexes <- sampleGroups$Basename[which(sampleGroups$Individual_ID == each)]
+    if(length(bsindexes) > 1){
+      for(i in 1:(length(bsindexes)-1)){
+        for(j in (i+1):length(bsindexes)){
+          plot(rsbetas[,bsindexes[i]], rsbetas[,bsindexes[j]], xlab = "",ylab = "", pch = 16, xlim = c(0,1), ylim = c(0,1), main = each)
+          title(xlab = bsindexes[i], col.lab = xlabcol)
+          title(ylab = bsindexes[j], col.lab = ylabcol)
+        }
+      }
+    }
+
+}
+
 dev.off()
 
 


### PR DESCRIPTION
# Description

This pull request will fix a bug in diagnostic plot where it expect smutiple samples to plot agianats each other & adds further diagnostic plots for instance where samples are labellled as being genetically identical but data says they are not. 

## Issue ticket number

This pull request is to address issue: #196 .

## Type of pull request

- [X] Bug fix
- [ ] New feature/enhancement
- [ ] Code refactor
- [ ] Documentation update

## Checklist

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have tested my code to check that it is functional
- [ ] I have used linters to check for common sources of errors
- [ ] I have implemented fail safes in my code to account for edge cases
- [ ] I have made the corresponding changes to the documentation
