### PR TITLE
feat: Add more error logging to DNAm pipeline

### DIFF
--- a/array/DNAm/preprocessing/jobSubmission/1_runDNAmQC.sh
+++ b/array/DNAm/preprocessing/jobSubmission/1_runDNAmQC.sh
@@ -38,7 +38,8 @@ date -u
 echo Log files intially stored in: ${SLURM_SUBMIT_DIR}/QCDNAdata_${SLURM_JOB_ID}.log and ${SLURM_SUBMIT_DIR}/QCDNAdata_${SLURM_JOB_ID}.err
 
 config_file=$1
-source "${config_file}" || print_error_message \ "The provided config file was not sourced correctly." \
+source "${config_file}" || print_error_message \
+    "The provided config file was not sourced correctly." \
     "Please check the path you gave exists, exiting..." 
 
 echo "Processing data located in :" ${DATADIR}
@@ -59,6 +60,15 @@ if [[ "${config_malformed}" -ne 0 ]]; then
 fi
 
 Rscript installLibraries.r ${DATADIR}
+library_did_not_install=$?
+if [[ "${library_did_not_install}" -ne 0 ]]; then
+    print_error_message \
+        "A required library did not install properly." \
+        "Please check the error logs as to why this happened." \
+        "If the problem is not easily fixed, consider opening an issue." \
+        "https://github.com/ejh243/BrainFANS/issues/new/choose" \
+        "Exiting..."
+fi
 
 Rscript checkColnamesSampleSheet.r ${DATADIR}
 

--- a/array/DNAm/preprocessing/jobSubmission/1_runDNAmQC.sh
+++ b/array/DNAm/preprocessing/jobSubmission/1_runDNAmQC.sh
@@ -81,6 +81,12 @@ fi
 mkdir -p ${GDSDIR}/QCmetrics
 
 Rscript loadDataGDS.r ${DATADIR}
+gds_problem_identified=$?
+if [[ "${gds_problem_identified}" -ne 0 ]]; then
+    print_error_message \
+        "A problem with the GDS data has been identified." \
+        "Please check the error logs for more information, exiting..."
+fi
 
 chmod 755 ${DATADIR}/2_gds/raw.gds
 

--- a/array/DNAm/preprocessing/jobSubmission/1_runDNAmQC.sh
+++ b/array/DNAm/preprocessing/jobSubmission/1_runDNAmQC.sh
@@ -16,6 +16,15 @@
 
 #-----------------------------------------------------
 
+print_error_message() {
+    IFS=$'\n'
+    error_message=$*
+cat 1>&2 << MESSAGE
+ERROR:
+$error_message
+MESSAGE
+    exit 1
+}
 
 ## print start date and time
 echo Job started on:

--- a/array/DNAm/preprocessing/jobSubmission/1_runDNAmQC.sh
+++ b/array/DNAm/preprocessing/jobSubmission/1_runDNAmQC.sh
@@ -32,7 +32,10 @@ date -u
 
 echo Log files intially stored in: ${SLURM_SUBMIT_DIR}/QCDNAdata_${SLURM_JOB_ID}.log and ${SLURM_SUBMIT_DIR}/QCDNAdata_${SLURM_JOB_ID}.err
 
-source $1 || exit 1
+config_file=$1
+source "${config_file}" || print_error_message \
+    "The provided config file was not sourced correctly." \
+    "Please check the path you gave exists, exiting..." 
 
 echo "Processing data located in :" ${DATADIR}
 

--- a/array/DNAm/preprocessing/jobSubmission/1_runDNAmQC.sh
+++ b/array/DNAm/preprocessing/jobSubmission/1_runDNAmQC.sh
@@ -40,7 +40,7 @@ echo Log files intially stored in: ${SLURM_SUBMIT_DIR}/QCDNAdata_${SLURM_JOB_ID}
 config_file=$1
 source "${config_file}" || print_error_message \
     "The provided config file was not sourced correctly." \
-    "Please check the path you gave exists, exiting..." 
+    "Please check the path you gave ('$config_file') exists, exiting..." 
 
 echo "Processing data located in :" ${DATADIR}
 

--- a/array/DNAm/preprocessing/jobSubmission/1_runDNAmQC.sh
+++ b/array/DNAm/preprocessing/jobSubmission/1_runDNAmQC.sh
@@ -28,6 +28,7 @@ ERROR:
 ${error_message}
 ${NO_COLOUR}
 MESSAGE
+
     exit 1
 }
 

--- a/array/DNAm/preprocessing/jobSubmission/1_runDNAmQC.sh
+++ b/array/DNAm/preprocessing/jobSubmission/1_runDNAmQC.sh
@@ -33,8 +33,7 @@ date -u
 echo Log files intially stored in: ${SLURM_SUBMIT_DIR}/QCDNAdata_${SLURM_JOB_ID}.log and ${SLURM_SUBMIT_DIR}/QCDNAdata_${SLURM_JOB_ID}.err
 
 config_file=$1
-source "${config_file}" || print_error_message \
-    "The provided config file was not sourced correctly." \
+source "${config_file}" || print_error_message \ "The provided config file was not sourced correctly." \
     "Please check the path you gave exists, exiting..." 
 
 echo "Processing data located in :" ${DATADIR}
@@ -47,9 +46,11 @@ module load $RVERS   # load specified R version
 cd ${SCRIPTSDIR}/array/DNAm/preprocessing/
 
 Rscript checkRconfigFile.r ${DATADIR}
-if [[ $? -ne 0 ]]; then
-    echo "Malformed config file has been identified. Exiting..."
-    exit 1
+config_malformed=$?
+if [[ "${config_malformed}" -ne 0 ]]; then
+    print_error_message \
+        "Malformed config file has been identified." \
+        "Please check the error logs, exiting..."
 fi
 
 Rscript installLibraries.r ${DATADIR}

--- a/array/DNAm/preprocessing/jobSubmission/1_runDNAmQC.sh
+++ b/array/DNAm/preprocessing/jobSubmission/1_runDNAmQC.sh
@@ -56,7 +56,7 @@ config_malformed=$?
 if [[ "${config_malformed}" -ne 0 ]]; then
     print_error_message \
         "Malformed config file has been identified." \
-        "Please check the error logs, exiting..."
+        "Please check the error logs for more information, exiting..."
 fi
 
 Rscript installLibraries.r ${DATADIR}
@@ -75,7 +75,7 @@ sample_sheet_malformed=$?
 if [[ "${sample_sheet_malformed}" -ne 0 ]]; then
     print_error_message \
         "Malformed sample sheet has been identified." \
-        "Please check the error logs, exiting..."
+        "Please check the error logs for more information, exiting..."
 fi
 
 mkdir -p ${GDSDIR}/QCmetrics

--- a/array/DNAm/preprocessing/jobSubmission/1_runDNAmQC.sh
+++ b/array/DNAm/preprocessing/jobSubmission/1_runDNAmQC.sh
@@ -71,6 +71,12 @@ if [[ "${library_did_not_install}" -ne 0 ]]; then
 fi
 
 Rscript checkColnamesSampleSheet.r ${DATADIR}
+sample_sheet_malformed=$?
+if [[ "${sample_sheet_malformed}" -ne 0 ]]; then
+    print_error_message \
+        "Malformed sample sheet has been identified." \
+        "Please check the error logs, exiting..."
+fi
 
 mkdir -p ${GDSDIR}/QCmetrics
 

--- a/array/DNAm/preprocessing/jobSubmission/1_runDNAmQC.sh
+++ b/array/DNAm/preprocessing/jobSubmission/1_runDNAmQC.sh
@@ -19,9 +19,14 @@
 print_error_message() {
     IFS=$'\n'
     error_message=$*
+    RED='[0;31m'
+    NO_COLOUR='[0m'
+
 cat 1>&2 << MESSAGE
+${RED}
 ERROR:
-$error_message
+${error_message}
+${NO_COLOUR}
 MESSAGE
     exit 1
 }


### PR DESCRIPTION
# Description

This pull request will add more in depth error logging to the main DNAm job submission script. If an R script fails that is needed for subsequent steps (for example if the sample sheet is in the incorrect format), then a helpful error message will be written to the error logs (and the script will exit early with exit code 1).

## Example
The error logs will look like this:

![image](https://github.com/user-attachments/assets/1b7dade8-779d-445e-9fc2-6319de860917)

## Issue ticket number

This pull request is to address issue: #213.

## Type of pull request

- [ ] Bug fix
- [x] New feature/enhancement
- [ ] Code refactor
- [ ] Documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code to check that it is functional
- [ ] I have used linters to check for common sources of errors
- [ ] I have implemented fail safes in my code to account for edge cases
- [ ] I have made the corresponding changes to the documentation
