### PR TITLE
Add repository version to QC rmarkdown

### DIFF
--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -27,9 +27,8 @@ library(data.table)
 source(args[4]) ### change the content of this file to run QC with different thresholds
 ### prior to running this Rmarkdown which summarises the QC output, QC metrics must have been generated
 
-
-refDir <- args[3]
 dataDir <- args[2]
+refDir <- args[3]
 most_recent_git_tag <- args[6]
 current_commit_hash <- args[7]
 setwd(dataDir) 

--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -30,6 +30,8 @@ source(args[4]) ### change the content of this file to run QC with different thr
 
 refDir <- args[3]
 dataDir <- args[2]
+most_recent_git_tag <- args[6]
+current_commit_hash <- args[7]
 setwd(dataDir) 
 
 qcData <-paste0(dataDir, "/2_gds/QCmetrics/QCmetrics.rdata")
@@ -151,6 +153,8 @@ This report documents the internal quality control (QC) process of DNA methylati
 **Array used:** `r arrayType`
 
 **Date of QC:** `r format(Sys.Date(), format="%d %B %Y")`
+
+**Most recent BrainFANS version:** `r most_recent_git_tag` (specific commit hash used: `r current_commit_hash`)
 
 **Sample tissue:** `r tissueType` 
 

--- a/array/DNAm/preprocessing/jobSubmission/1_runDNAmQC.sh
+++ b/array/DNAm/preprocessing/jobSubmission/1_runDNAmQC.sh
@@ -54,7 +54,11 @@ Rscript calcQCMetrics.r ${DATADIR} ${REFDIR}
 
 Rscript clusterCellTypes.r ${DATADIR} ${REFDIR}
 
-Rscript -e "rmarkdown::render('QC.rmd', output_file='QC.html')" --args ${DATADIR} ${REFDIR} ${RCONFIG} $USER
+most_recent_git_tag=$(git describe --tags)
+current_commit_hash=$(git rev-parse HEAD)
+Rscript -e "rmarkdown::render('QC.rmd', output_file='QC.html')" \
+    --args "${DATADIR}" "${REFDIR}" "${RCONFIG}" "${USER}" \
+    "${most_recent_git_tag}" "${current_commit_hash}"
 
 ## mv markdown report to correct location
 mv QC.html ${GDSDIR}/QCmetrics/


### PR DESCRIPTION
# Description

This pull request will add this line:

![image](https://github.com/user-attachments/assets/d9993016-976b-4ec5-a8a1-2ad1930daf13)

To the QC.html report under the "Study Information" field.

## Issue ticket number

This pull request is to address issue: #211.

## Type of pull request

- [ ] Bug fix
- [x] New feature/enhancement
- [ ] Code refactor
- [ ] Documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code to check that it is functional
- [ ] I have used linters to check for common sources of errors
- [ ] I have implemented fail safes in my code to account for edge cases
- [ ] I have made the corresponding changes to the documentation
