### PR TITLE
fix: predictedduplicates containing empty strings

### DIFF
--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -943,6 +943,12 @@ QCmetrics[["predictedduplicates"]] <- predictedduplicates
 # column to be NA for samples that did not pass QC.
 QCmetrics[["predictedduplicates"]][!passQC] <- NA
 
+# predictedduplicates will contain empty strings for samples that have been
+# removed. If these aren't removed from predictedduplicates, the below table 
+# will confusingly state that each of these removed samples belong to the same
+# individual.
+predictedduplicates <- predictedduplicates[nzchar(predictedduplicates)]
+
 ```
 
 Post QC we identified `r length(unique(predictedduplicates))` genetically unique individuals with the following distribution of number of samples per individual.


### PR DESCRIPTION
# Description

This pull request will remove samples (from QC) would have "" in their spot in predictedduplicates. These are then clustered together in the table call below, resulting in section 4.2 giving a confusing result (saying these samples belong to the same individual despite being removed). This no longer occurs.


## Issue ticket number

This pull request is to address issue: #214.

## Type of pull request

- [x] Bug fix
- [ ] New feature/enhancement
- [ ] Code refactor
- [ ] Documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code to check that it is functional
- [ ] I have used linters to check for common sources of errors
- [ ] I have implemented fail safes in my code to account for edge cases
- [ ] I have made the corresponding changes to the documentation
