### PR TITLE
fix: PCs identified text showing incorrect number

### DIFF
--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -433,7 +433,7 @@ Detection p values provide a measure of the accuracy of DNAm value at a specific
 
 ## Principal Component Analysis
 
-To identify and visually inspect potential outliers we performed principal component analysis on the autosomal probes. We identified `r length(which(ctrl.pca > 0.01))` PCs which explained > 1% of the variance and focused on these for characterisation. 
+To identify and visually inspect potential outliers we performed principal component analysis on the autosomal probes. We identified `r length(which(betas.pca > 0.01))` PCs which explained > 1% of the variance and focused on these for characterisation. 
 
 ```{r, betasPCAPlot, fig.width = 6, fig.height = 4, echo = FALSE}
 par(mar = c(4,4,1,1))

--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -441,7 +441,7 @@ plot(1:20, betas.pca[1:20]*100, type = "b", ylab = "% variance explained", xlab 
 abline(h=1, col = "red")
 ```
 
-We will use histograms and scatterplots below to visualally inspect for potential outliers or patterns in the data. In the histograms below, the red dashed lines indicate 2 and 3 SD from the mean. 
+We will use histograms and scatterplots below to visually inspect for potential outliers or patterns in the data. In the histograms below, the red dashed lines indicate 2 and 3 SD from the mean. 
 
 ```{r, echo=FALSE, fig.height=4, betasPCAHist, fig.width=15}
 par(mar = c(4,4,4,1))


### PR DESCRIPTION
# Description

This pull request will fix the reported number of principal components that are focused on for characterisation. 
![image](https://github.com/user-attachments/assets/9d0d51f7-9b67-46d1-ad71-4759c8541220)

Previously the histogram plots were using `betas.pca` and the text alluding to this number was using `ctrl.pca`. They now both agree with one another (`betas.pca` is used in both sections).

I also fixed a typo that I didn't want to put in its own pull request as it's kinda related to the same section and I'm lazy.

## Issue ticket number

This pull request is to address issue: #195.

## Type of pull request

- [x] Bug fix
- [ ] New feature/enhancement
- [ ] Code refactor
- [ ] Documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my code to check that it is functional
- [ ] I have used linters to check for common sources of errors
- [ ] I have implemented fail safes in my code to account for edge cases
- [ ] I have made the corresponding changes to the documentation
