### PR TITLE
Remove tech var and bio var variables

### DIFF
--- a/array/DNAm/config/config.example.r
+++ b/array/DNAm/config/config.example.r
@@ -5,12 +5,8 @@ tissueType<-"brain" # needs to be brain or blood to generate relevant cell compo
 arrayType<-"V2" # must be one of "450K" / "V1" / "V2"
 
 
-## technical variables
-techVar<-c("Sentrix_ID","Sentrix_Position")
-
-
-## biological variables
-bioVar<-c("Individual_ID","Cell_Type","Sex")
+## project variables
+projVar<-c("Cell_Type", "Sex") # Used to colour plots
 
 
 ## QC thresholds

--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -40,7 +40,6 @@ if(!"Cell_Type" %in% colnames(QCmetrics)){
 }
 
 
-nSamAll<-nrow(QCmetrics)
 nSamIP<-sum(QCmetrics$intensPASS)
 
 par(mar = c(4,4,1,1))

--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -110,7 +110,9 @@ remove_unwanted_columns <- function(columns, QCmetrics) {
 define_plot_parameters <- function(QCmetrics, projVar) {
   plot_columns <- remove_unwanted_columns(projVar, QCmetrics)
 
-  plotCols <- data.frame("Basename" = QCmetrics[["Basename"]])
+  plotCols <- data.frame("Basename" = QCmetrics[["Basename"]],
+                        "Sentrix_ID" = substr(QCmetrics[["Basename"]], 1, 12),
+                        "Sentrix_Position" = substr(QCmetrics[["Basename"]], 14, 19))
   legendParams <- list()
 
   for (column_name in plot_columns) {

--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -27,6 +27,7 @@ library(data.table)
 source(args[4]) ### change the content of this file to run QC with different thresholds
 ### prior to running this Rmarkdown which summarises the QC output, QC metrics must have been generated
 
+
 refDir <- args[3]
 dataDir <- args[2]
 setwd(dataDir) 
@@ -38,6 +39,10 @@ load(qcData)
 if(!"Cell_Type" %in% colnames(QCmetrics)){
   QCmetrics$Cell_Type <- NA
 }
+
+# extract Sentrix_ID and _Position from basename as excel can sometimes cause them to be in sci not
+QCmetrics[["Sentrix_ID"]] <- substr(QCmetrics[["Basename"]], 1, 12)
+QCmetrics[["Sentrix_Position"]] = substr(QCmetrics[["Basename"]], 14, 19)
 
 
 nSamIP<-sum(QCmetrics$intensPASS)
@@ -108,11 +113,10 @@ remove_unwanted_columns <- function(columns, QCmetrics) {
 }
 
 define_plot_parameters <- function(QCmetrics, projVar) {
-  plot_columns <- remove_unwanted_columns(projVar, QCmetrics)
+  plot_columns <- c(remove_unwanted_columns(projVar, QCmetrics), "Sentrix_ID", "Sentrix_Position")
 
-  plotCols <- data.frame("Basename" = QCmetrics[["Basename"]],
-                        "Sentrix_ID" = substr(QCmetrics[["Basename"]], 1, 12),
-                        "Sentrix_Position" = substr(QCmetrics[["Basename"]], 14, 19))
+  plotCols <- data.frame("Basename" = QCmetrics[["Basename"]])
+                     
   legendParams <- list()
 
   for (column_name in plot_columns) {
@@ -161,10 +165,32 @@ These are only included if they are categorical. For this study the following pr
 
 ```{r projVarSpecification, echo = FALSE, results = "asis", echo = FALSE}
 
+send_removal_message <- function(column_name, QCmetrics) {
+  column <- parse_column(column_name, QCmetrics)
+
+  removal_message <- function(column_name, reason) {
+    message("Column ", column_name, " was excluded because ", reason,
+      ". Associated plots would give no useful information.")
+  }
+
+  if (all(is.na(column))) {
+    removal_message(column_name, "all values were labelled as missing")
+    return()
+  }
+  if (length(unique(column)) == 1L) {
+    removal_message(column_name, "all values were equivalent")
+    return()
+  }
+  if (anyDuplicated(column) == 0L) {
+    removal_message(column_name, "all values were distinct")
+    return()
+  }
+}
+
 for (column_name in projVar) send_removal_message(column_name, QCmetrics)
 
 projVar <- remove_unwanted_columns(projVar, QCmetrics)
-for(item in prrojVar){
+for(item in projVar){
   pander(
     as.data.frame(table(QCmetrics[, item])),
     caption = paste("Summary of samples categorised by", item),

--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -108,9 +108,8 @@ remove_unwanted_columns <- function(columns, QCmetrics) {
   return(columns[columns_to_keep])
 }
 
-define_plot_parameters <- function(QCmetrics, techVar, bioVar) {
-  potential_plot_columns <- c(techVar, bioVar)
-  plot_columns <- remove_unwanted_columns(potential_plot_columns, QCmetrics)
+define_plot_parameters <- function(QCmetrics, projVar) {
+  plot_columns <- remove_unwanted_columns(projVar, QCmetrics)
 
   plotCols <- data.frame("Basename" = QCmetrics[["Basename"]])
   legendParams <- list()
@@ -130,9 +129,8 @@ define_plot_parameters <- function(QCmetrics, techVar, bioVar) {
 }
 
 
-if (!exists("techVar")) techVar <- NULL
-if (!exists("bioVar")) bioVar <- NULL
-plot_parameters <- define_plot_parameters(QCmetrics, techVar, bioVar)
+if (!exists("projVar")) projVar <- NULL
+plot_parameters <- define_plot_parameters(QCmetrics, projVar)
 plotCols <- plot_parameters[[1]]
 legendParams <- plot_parameters[[2]]
 ```
@@ -156,58 +154,16 @@ This report documents the internal quality control (QC) process of DNA methylati
 Data was loaded for `r nrow(QCmetrics)` samples from `r length(unique(QCmetrics$Individual_ID))` individuals.
 
 
-## Summary of Technical Variables
+## Summary of Project Variables
 
-These are only included if they are categorical. For this study the following technical variables were included:
+These are only included if they are categorical. For this study the following project variables were included:
 
-```{r techVarSpecification, results = "asis", echo = FALSE}
-send_removal_message <- function(column_name, QCmetrics) {
-  column <- parse_column(column_name, QCmetrics)
+```{r projVarSpecification, echo = FALSE, results = "asis", echo = FALSE}
 
-  removal_message <- function(column_name, reason) {
-    message("Column ", column_name, " was excluded because ", reason,
-      ". Associated plots would give no useful information.")
-  }
+for (column_name in projVar) send_removal_message(column_name, QCmetrics)
 
-  if (all(is.na(column))) {
-    removal_message(column_name, "all values were labelled as missing")
-    return()
-  }
-  if (length(unique(column)) == 1L) {
-    removal_message(column_name, "all values were equivalent")
-    return()
-  }
-  if (anyDuplicated(column) == 0L) {
-    removal_message(column_name, "all values were distinct")
-    return()
-  }
-}
-
-for (column_name in techVar) send_removal_message(column_name, QCmetrics)
-
-techVar <- remove_unwanted_columns(techVar, QCmetrics)
-for(item in techVar){
-  tabTemp<-as.data.frame(table(QCmetrics[,item]))
-  if(nrow(tabTemp) < 2){
-    pander(
-      t(tabTemp),
-      caption = paste("Summary of samples categorised by", item),
-      row.names = c("Variable", "Number of Samples")
-    )
-  }
-}
-```
-
-## Summary of Biological Variables
-
-These are only included if they are categorical. For this study the following biological variables were included:
-
-```{r bioVarSpecification, echo = FALSE, results = "asis", echo = FALSE}
-
-for (column_name in bioVar) send_removal_message(column_name, QCmetrics)
-
-bioVar <- remove_unwanted_columns(bioVar, QCmetrics)
-for(item in bioVar){
+projVar <- remove_unwanted_columns(projVar, QCmetrics)
+for(item in prrojVar){
   pander(
     as.data.frame(table(QCmetrics[, item])),
     caption = paste("Summary of samples categorised by", item),
@@ -218,7 +174,7 @@ for(item in bioVar){
 
 # Quality Control: Data Quality
 
-A series of quality control (QC) metrics have been calculated for all samples and are reported below. After reviewing this report, exclusion thresholds to identify poorly performing samples can be provided to the normalisation script. For some QC metrics we use the provided technical and biological variables to aid identification of any patterns behind sample failures or artefacts that need to be included in the analysis. 
+A series of quality control (QC) metrics have been calculated for all samples and are reported below. After reviewing this report, exclusion thresholds to identify poorly performing samples can be provided to the normalisation script. For some QC metrics we use the provided project variables to aid identification of any patterns behind sample failures or artefacts that need to be included in the analysis. 
 
 
 ## Signal Intensities

--- a/array/DNAm/preprocessing/checkRconfigFile.r
+++ b/array/DNAm/preprocessing/checkRconfigFile.r
@@ -31,7 +31,7 @@ qcRmdParams <- c("projectTitle", "processedBy")
 qcthres <- c("thresBS", "intenThres", "nvThres", "perMiss")
 logicalParams <- c("sexCheck", "snpCheck", "ctCheck")
 
-ungrouped <- c("tissueType", "arrayType", "techVar", "bioVar")
+ungrouped <- c("tissueType", "arrayType", "projVar")
 
 ctThres <- c("studentThres", "nSDThres")
 ctCellParams <- c("predDistinctCT", "neunCT")
@@ -80,24 +80,9 @@ if (!toupper(arrayType) %in% c("HM450K", "V1", "V2")) {
   warning("\nUnrecognised arrayType. Must be 'HM450K', 'V1' or 'V2'\n")
 }
 
-
-for (i in c("Individual_ID", "Sex")) {
-  if (!i %in% bioVar) {
-    bad_parameter_exists <- TRUE
-    warning("\n'", i, "' must be included in bioVar\n")
-  }
-}
-
-if (!"Cell_Type" %in% bioVar && ctCheck) {
+if (!"Cell_Type" %in% projVar && ctCheck) {
   bad_parameter_exists <- TRUE
-  warning("\n'Cell_Type' must be included in bioVar if 'ctCheck' is true\n")
-}
-
-for (i in c("Sentrix_ID", "Sentrix_Position")) {
-  if (!i %in% techVar) {
-    bad_parameter_exists <- TRUE
-    warning("\n'", i, "' must be included in techVar\n")
-  }
+  warning("\n'Cell_Type' must be included in projVar if 'ctCheck' is true\n")
 }
 
 if (bad_parameter_exists) {


### PR DESCRIPTION
# Description

This pull request will remove the techVar and bioVar variables from the config.example.r,  checkRconfigFile.r and QC.rmd files and replace them with an overal projVar (project variable).

It will also hard code Sentrix_ID and Sentrix_Position into the QC.rmd doc plots.

## Issue ticket number

This pull request is to address issues: #33, #188 and #216

## Type of pull request

- [x] Bug fix
- [x] New feature/enhancement
- [ ] Code refactor
- [ ] Documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code to check that it is functional
- [ ] I have used linters to check for common sources of errors
- [ ] I have implemented fail safes in my code to account for edge cases
- [ ] I have made the corresponding changes to the documentation
