### PR TITLE
Add p filter for probe removal

### DIFF
--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -414,7 +414,10 @@ for(i in 2:ncol(plotCols)){
 
 ## Detection P values
 
-Detection p values provide a measure of the accuracy of DNAm value at a specific probe for a specific sample above background noise. At this stage we are only interested in sample filtering; probe-level filtering will happen after we have removed samples. For each sample we calculate the number of sites where the signal is not detectable above the background. Samples with a high percentage of these sites are excluded. In this data `r nrow(QCmetrics)-sum(QCmetrics$pFilter, na.rm = TRUE)` samples are recommended for removal. 
+Detection p values provide a measure of the accuracy of DNAm value at a specific probe for a specific sample above background noise and is performed at both a sample and probe level. 
+For each sample we calculate the number of sites where the signal is not detectable above the background. Samples with a high percentage of these sites are excluded. In this data `r nrow(QCmetrics)-sum(QCmetrics$pFilter, na.rm = TRUE)` samples are recommended for removal.
+For each probe we calculate the percentage of samples where the signal is not detectable above the background. Probes with a high percentage of samples are excluded. In this data `r nrow(probeFilt) - sum(probeFilt[,"pFiltProbesPass"])` probes are recommeded for removal.
+Additionally, probes with a high percentage of samples with a beadcount less than 3 are excluded. In this data `r nrow(probeFilt) - sum(probeFilt[,"beadFiltPass"])` probes are recommend for removal.
 
 
 ## Principal Component Analysis


### PR DESCRIPTION
# Description

This pull request will add in steps to identify and filter failed probes prior to normalisation.

1. Creates a failedProbes object in the calcQCmetrics.r script which flags low beadcount and low p val probes for removal and saves as part of the QCmetrics.rdata object

2. Edits QC.rmd section 2.7 Detection P values to output the number of failed detP probes, and number of beadcount probes

3. Edits normalisation.r script to remove probes recommended for removal prior to normalisation 

some of the code is adapted from here: https://rdrr.io/bioc/bigmelon/src/R/pfilterGds.R 

## Issue ticket number #192 

This pull request is to address issue: #number. #192

## Type of pull request

- [ ] Bug fix
- [x] New feature/enhancement
- [ ] Code refactor
- [ ] Documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code to check that it is functional
- [ ] I have used linters to check for common sources of errors
- [ ] I have implemented fail safes in my code to account for edge cases
- [ ] I have made the corresponding changes to the documentation
