### PR TITLE
Cortical clock check

### DIFF
--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -1035,13 +1035,13 @@ if (ageExists) {
 ```{r dnamage, results = 'asis', echo = FALSE, eval = ageValid}
 cat(
 "## Age Prediction\n",
-"The age of samples can be predicted from the DNAm data using the Epigenetic
-Clock algorithm developed by Steve Horvath. These predicted values are compared
-to the samples' reported ages. As on a sample level this estimaion can be
-inaccurate it is used as a quality check of the overall data set and not as a
-reason to exclude individual samples. The overall correlation was ",
+"The age of samples can be predicted from the DNAm data using the Epigenetic",
+"Clock algorithm developed by Steve Horvath. These predicted values are compared",
+"to the samples' reported ages. As on a sample level this estimaion can be",
+"inaccurate it is used as a quality check of the overall data set and not as a",
+"reason to exclude individual samples. The overall correlation was",
 signif(cor(as.numeric(QCmetrics$Age), QCmetrics$DNAmAge, use = 'pairwise.complete.obs'),3),
-"and the root mean square error was ",
+"and the root mean square error was",
 signif(sqrt(mean((QCmetrics$Age-QCmetrics$DNAmAge)^2, na.rm = TRUE)),3),
 "years.")
 ```
@@ -1059,9 +1059,9 @@ abline(a = 0, b = 1)
 
 ```{r ccdnamage, results = 'asis', echo = FALSE, eval = CCDNAmAgeExists}
 cat(
-"We also applied a custom clock algorithm developed secifically for cortical samples. The overall correlation was ",
+"We also applied a custom clock algorithm developed secifically for cortical samples. The overall correlation was",
 signif(cor(as.numeric(QCmetrics$Age), QCmetrics$CCDNAmAge, use = "pairwise.complete.obs"),3),
-"and the root mean square error was ",
+"and the root mean square error was",
 signif(sqrt(mean((QCmetrics$Age-QCmetrics$CCDNAmAge)^2, na.rm = TRUE)),3),
 "years.")
 ```

--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -1019,7 +1019,7 @@ if(length(errorIndexes) > 0){
 ```
 
 
-## Age Prediction
+<!-- Age Prediction -->
 
 ```{r ageSetup, echo=FALSE}
 ageExists <- "Age" %in% colnames(QCmetrics) 
@@ -1034,6 +1034,7 @@ if (ageExists) {
 
 ```{r dnamage, results = 'asis', echo = FALSE, eval = ageValid}
 cat(
+"## Age Prediction\n",
 "The age of samples can be predicted from the DNAm data using the Epigenetic
 Clock algorithm developed by Steve Horvath. These predicted values are compared
 to the samples' reported ages. As on a sample level this estimaion can be

--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -1037,7 +1037,7 @@ cat(
 "## Age Prediction\n",
 "The age of samples can be predicted from the DNAm data using the Epigenetic",
 "Clock algorithm developed by Steve Horvath. These predicted values are compared",
-"to the samples' reported ages. As on a sample level this estimaion can be",
+"to the samples' reported ages. As on a sample level this estimation can be",
 "inaccurate it is used as a quality check of the overall data set and not as a",
 "reason to exclude individual samples. The overall correlation was",
 signif(cor(as.numeric(QCmetrics$Age), QCmetrics$DNAmAge, use = 'pairwise.complete.obs'),3),

--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -1032,7 +1032,7 @@ if (ageExists) {
 ```
 
 
-```{r dnamage, eval = ageValid}
+```{r dnamage, results = 'asis', echo = FALSE, eval = ageValid}
 cat(
 "The age of samples can be predicted from the DNAm data using the Epigenetic
 Clock algorithm developed by Steve Horvath. These predicted values are compared
@@ -1056,7 +1056,7 @@ abline(model, lty = 2)
 abline(a = 0, b = 1)
 ```
 
-```{r ccdnamage, eval = CCDNAmAgeExists}
+```{r ccdnamage, results = 'asis', echo = FALSE, eval = CCDNAmAgeExists}
 cat(
 "We also applied a custom clock algorithm developed secifically for cortical samples. The overall correlation was ",
 signif(cor(as.numeric(QCmetrics$Age), QCmetrics$CCDNAmAge, use = "pairwise.complete.obs"),3),

--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -1022,29 +1022,55 @@ if(length(errorIndexes) > 0){
 ## Age Prediction
 
 ```{r ageSetup, echo=FALSE}
-show_text <- "Age" %in% colnames(QCmetrics)
+ageExists <- "Age" %in% colnames(QCmetrics) 
+ageValid <- FALSE
+CCDNAmAgeExists <- FALSE
+if (ageExists) {
+  ageValid <- (sum(!is.na(QCmetrics$Age)) > 1)
+  CCDNAmAgeExists <- "CCDNAmAge" %in% colnames(QCmetrics) && ageValid
+}
 ```
 
-The age of samples can be predicted from the DNAm data using the Epigenetic Clock algorithm developed by Steve Horvath. These predicted values are compared to the samples' reported ages. As on a sample level this estimaion can be inaccurate it is used as a quality check of the overall data set and not as a reason to exclude individual samples. The overall correlation was `r if("Age" %in% colnames(QCmetrics) & sum(!is.na(QCmetrics$Age)) ) {signif(cor(as.numeric(QCmetrics$Age), QCmetrics$DNAmAge, use = "pairwise.complete.obs"),3)}` and the root mean square error was `r if("Age" %in% colnames(QCmetrics) & sum(!is.na(QCmetrics$Age))){signif(sqrt(mean((QCmetrics$Age-QCmetrics$DNAmAge)^2, na.rm = TRUE)),3)}` years. We also applied a custom clock algorithm developed secifically for cortical samples. The overall correlation was `r if("Age" %in% colnames(QCmetrics) & sum(!is.na(QCmetrics$Age))){signif(cor(as.numeric(QCmetrics$Age), QCmetrics$CCDNAmAge, use = "pairwise.complete.obs"),3)}` and the root mean square error was `r if("Age" %in% colnames(QCmetrics) & sum(!is.na(QCmetrics$Age))){signif(sqrt(mean((QCmetrics$Age-QCmetrics$CCDNAmAge)^2, na.rm = TRUE)),3)}` years.
 
-```{r dnamage, echo=FALSE, fig.width = 10, fig.height = 5, eval = show_text}
-if("Age" %in% colnames(QCmetrics) & sum(!is.na(QCmetrics$Age)) > 1){
-  par(mfrow = c(1,2))
-  
-  model<-lm(QCmetrics$Age~QCmetrics$DNAmAge)
-  plot(QCmetrics$DNAmAge, QCmetrics$Age, xlab = "Predicted", ylab = "Reported", main="Horvath Clock", pch=16, col="purple")
-  title(main = paste("r = ", signif(cor(QCmetrics$DNAmAge, QCmetrics$Age, use = "pairwise.complete.obs"),3)), line = 0.5, adj = 1)
-  title(main = paste("RMSE = ", signif(sqrt(mean(abs(QCmetrics$DNAmAge-QCmetrics$Age)^2, na.rm = TRUE)),3)), line = 2, adj = 1)
-  abline(model, lty = 2)
-  abline(a = 0, b = 1)
-  
-  model<-lm(QCmetrics$Age~QCmetrics$CCDNAmAge)
-  plot(QCmetrics$CCDNAmAge, QCmetrics$Age, xlab = "Predicted", ylab = "Reported", main="Cortical Clock", pch=16, col="purple")
-  title(main = paste("r = ", signif(cor(QCmetrics$CCDNAmAge, QCmetrics$Age, use = "pairwise.complete.obs"),3)), line = 0.5, adj = 1)
-  title(main = paste("RMSE = ", signif(sqrt(mean(abs(QCmetrics$CCDNAmAge-QCmetrics$Age)^2, na.rm = TRUE)),3)), line = 2, adj = 1)
-  abline(model, lty = 2)
-  abline(a = 0, b = 1)
-}
+```{r dnamage, eval = ageValid}
+cat(
+"The age of samples can be predicted from the DNAm data using the Epigenetic
+Clock algorithm developed by Steve Horvath. These predicted values are compared
+to the samples' reported ages. As on a sample level this estimaion can be
+inaccurate it is used as a quality check of the overall data set and not as a
+reason to exclude individual samples. The overall correlation was ",
+signif(cor(as.numeric(QCmetrics$Age), QCmetrics$DNAmAge, use = 'pairwise.complete.obs'),3),
+"and the root mean square error was ",
+signif(sqrt(mean((QCmetrics$Age-QCmetrics$DNAmAge)^2, na.rm = TRUE)),3),
+"years.")
+```
+
+```{r dnamage-models echo=FALSE, fig.width = 10, fig.height = 5, eval = ageValid}
+par(mfrow = c(1,1))
+
+model<-lm(QCmetrics$Age~QCmetrics$DNAmAge)
+plot(QCmetrics$DNAmAge, QCmetrics$Age, xlab = "Predicted", ylab = "Reported", main="Horvath Clock", pch=16, col="purple")
+title(main = paste("r = ", signif(cor(QCmetrics$DNAmAge, QCmetrics$Age, use = "pairwise.complete.obs"),3)), line = 0.5, adj = 1)
+title(main = paste("RMSE = ", signif(sqrt(mean(abs(QCmetrics$DNAmAge-QCmetrics$Age)^2, na.rm = TRUE)),3)), line = 2, adj = 1)
+abline(model, lty = 2)
+abline(a = 0, b = 1)
+```
+
+```{r ccdnamage, eval = CCDNAmAgeExists}
+cat(
+"We also applied a custom clock algorithm developed secifically for cortical samples. The overall correlation was ",
+signif(cor(as.numeric(QCmetrics$Age), QCmetrics$CCDNAmAge, use = "pairwise.complete.obs"),3),
+"and the root mean square error was ",
+signif(sqrt(mean((QCmetrics$Age-QCmetrics$CCDNAmAge)^2, na.rm = TRUE)),3),
+"years.")
+```
+```{r ccdnamage-model, echo=FALSE, fig.width = 10, fig.height = 5, eval = CCDNAmAgeExists}
+model<-lm(QCmetrics$Age~QCmetrics$CCDNAmAge)
+plot(QCmetrics$CCDNAmAge, QCmetrics$Age, xlab = "Predicted", ylab = "Reported", main="Cortical Clock", pch=16, col="purple")
+title(main = paste("r = ", signif(cor(QCmetrics$CCDNAmAge, QCmetrics$Age, use = "pairwise.complete.obs"),3)), line = 0.5, adj = 1)
+title(main = paste("RMSE = ", signif(sqrt(mean(abs(QCmetrics$CCDNAmAge-QCmetrics$Age)^2, na.rm = TRUE)),3)), line = 2, adj = 1)
+abline(model, lty = 2)
+abline(a = 0, b = 1)
 ```
 
 

--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -1046,7 +1046,7 @@ signif(sqrt(mean((QCmetrics$Age-QCmetrics$DNAmAge)^2, na.rm = TRUE)),3),
 "years.")
 ```
 
-```{r dnamage-models echo=FALSE, fig.width = 10, fig.height = 5, eval = ageValid}
+```{r dnamage-models, echo=FALSE, fig.width = 10, fig.height = 5, eval = ageValid}
 par(mfrow = c(1,1))
 
 model<-lm(QCmetrics$Age~QCmetrics$DNAmAge)

--- a/array/DNAm/preprocessing/calcQCMetrics.r
+++ b/array/DNAm/preprocessing/calcQCMetrics.r
@@ -218,15 +218,15 @@ if(!"DNAmAge" %in% colnames(QCmetrics)){
 
 # NOTE this currently averages beta values accross duplicated probes
 # calc Cortical Clock Age
-if(!"CCDNAmAge" %in% colnames(QCmetrics)){	
+if ((!"CCDNAmAge" %in% colnames(QCmetrics)) && tolower(tissueType) == "brain") {
 	print("Calculating Shireby's Cortical Clock epigenetic age")
 	CC_coef<-read.csv(paste0(refDir, "/CortexClock/CorticalClockCoefficients.csv"), stringsAsFactors = FALSE)
 	anti.trafo= function(x,adult.age=20) { ifelse(x<0, (1+adult.age)*exp(x)-1, (1+adult.age)*x+adult.age) }
 	if(arrayType == "V2"){
 		cc <- CC_coef[CC_coef$probe %in% row.names(epicv2clean(betas(gfile)[])),]
-		CCDNAmAge<-	anti.trafo(as.numeric(CC_coef[1,2] + t(epicv2clean(betas(gfile)[])[row.names(epicv2clean(betas(gfile)[])) %in% CC_coef[-1,1],]) %*% cc[,2]))
+		CCDNAmAge<- anti.trafo(as.numeric(CC_coef[1,2] + t(epicv2clean(betas(gfile)[])[row.names(epicv2clean(betas(gfile)[])) %in% CC_coef[-1,1],]) %*% cc[,2]))
 	} else {
-		CCDNAmAge<-	anti.trafo(as.numeric(CC_coef[1,2] + t(betas(gfile)[][CC_coef[-1,1],])  %*% CC_coef[-1,2]))
+		CCDNAmAge<- anti.trafo(as.numeric(CC_coef[1,2] + t(betas(gfile)[][CC_coef[-1,1],]) %*% CC_coef[-1,2]))
 	}
 
 	QCmetrics<-cbind(QCmetrics,CCDNAmAge)

--- a/array/DNAm/preprocessing/calcQCMetrics.r
+++ b/array/DNAm/preprocessing/calcQCMetrics.r
@@ -192,10 +192,16 @@ if(!"PC1_betas" %in% colnames(QCmetrics)){
 if(!"pFilter" %in% colnames(QCmetrics)){	
 	print("Running pfilter")
 
-	pFOut<-apply.gdsn(node = pvals(gfile), margin = 2, FUN = function(x,
-								   y, z) {
+	pFOut<-apply.gdsn(
+		node = pvals(gfile),
+		margin = 2,
+		FUN = function(x, y, z) {
 			(sum(x > y, na.rm = TRUE)) < ((sum(!is.na(x)) * z)/100)
-		}, as.is = "logical", y = 0.05, z = 1)
+		},
+		as.is = "logical",
+		y = 0.05,
+		z = 1
+	)
 
 	pFOut[!QCmetrics$intensPASS]<-NA
 	QCmetrics<-cbind(QCmetrics,"pFilter"= pFOut)

--- a/array/DNAm/preprocessing/calcQCMetrics.r
+++ b/array/DNAm/preprocessing/calcQCMetrics.r
@@ -221,7 +221,9 @@ if(!"DNAmAge" %in% colnames(QCmetrics)){
 if ((!"CCDNAmAge" %in% colnames(QCmetrics)) && tolower(tissueType) == "brain") {
 	print("Calculating Shireby's Cortical Clock epigenetic age")
 	CC_coef<-read.csv(paste0(refDir, "/CortexClock/CorticalClockCoefficients.csv"), stringsAsFactors = FALSE)
-	anti.trafo= function(x,adult.age=20) { ifelse(x<0, (1+adult.age)*exp(x)-1, (1+adult.age)*x+adult.age) }
+	anti.trafo <- function(x,adult.age=20) { 
+		ifelse(x<0, (1+adult.age)*exp(x)-1, (1+adult.age)*x+adult.age) 
+	}
 	if(arrayType == "V2"){
 		cc <- CC_coef[CC_coef$probe %in% row.names(epicv2clean(betas(gfile)[])),]
 		CCDNAmAge<- anti.trafo(as.numeric(CC_coef[1,2] + t(epicv2clean(betas(gfile)[])[row.names(epicv2clean(betas(gfile)[])) %in% CC_coef[-1,1],]) %*% cc[,2]))


### PR DESCRIPTION
# Description

This pull request will add a check for the value of `tissueType` before executing the code block for the cortical clock.

There was also a lot of random indentation in this file, so I cleaned that up for everyone (some lines were indented for no reason, others had a mix of tabs and spaces).

## Problem

In QC.rmd we have the following lines where the `CCDNAmAge` field is expected to be in `QCMetrics`:
https://github.com/ejh243/BrainFANS/blob/6bbfbeceb89f79421ad8e94d1c47bf00ba2010ee/array/DNAm/preprocessing/QC.rmd#L1042-L1044

I'm not sure on how to proceed. I could make it so that this code also only runs when `tissueType == "brain"`, but I can't be sure if this is the desired behaviour. 

There are a few other instances of `CCDNAmAge` being used in QC.rmd. If the cortical clock is not ran, the required field in `QCMetrics` will not exist and this will fail. 

## Issue ticket number

This pull request is to address issue: #229.

## Type of pull request

- [ ] Bug fix
- [x] New feature/enhancement
- [ ] Code refactor
- [ ] Documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my code to check that it is functional
- [x] I have used linters to check for common sources of errors
- [ ] I have implemented fail safes in my code to account for edge cases
- [ ] I have made the corresponding changes to the documentation
