### PR TITLE
Move package installations

### DIFF
--- a/array/DNAm/preprocessing/installLibraries.r
+++ b/array/DNAm/preprocessing/installLibraries.r
@@ -68,14 +68,13 @@ install.packages(setdiff(pkgs_rep, rownames(installed.packages())),repos = "http
 
 #Additional packages for Brain Cell Proportion Prediction
 BiocManager::install(c("genefilter", "minfi"))
-pkgs_pred <- c("devtools","quadprog", "reshape2")
+pkgs_pred <- c("quadprog", "reshape2")
 install.packages(setdiff(pkgs_pred, rownames(installed.packages())),repos = "https://cran.r-project.org")
 
 # load devtools to install from GitHub
-library(devtools)
 install.packages("remotes") # install remotes package to install from github
-install_github("ds420/CETYGO", quiet=TRUE)
-install_github("EpigeneticsExeter/cdegUtilities", quiet=TRUE)
+remotes::install_github("ds420/CETYGO", quiet=TRUE)
+remotes::install_github("EpigeneticsExeter/cdegUtilities", quiet=TRUE)
 remotes::install_github("schalkwyk/wateRmelon")
 remotes::install_github("tjgorrie/bigmelon")
 

--- a/array/DNAm/preprocessing/installLibraries.r
+++ b/array/DNAm/preprocessing/installLibraries.r
@@ -71,7 +71,6 @@ BiocManager::install(c("genefilter", "minfi"))
 pkgs_pred <- c("quadprog", "reshape2")
 install.packages(setdiff(pkgs_pred, rownames(installed.packages())),repos = "https://cran.r-project.org")
 
-# load devtools to install from GitHub
 install.packages("remotes") # install remotes package to install from github
 remotes::install_github("ds420/CETYGO", quiet=TRUE)
 remotes::install_github("EpigeneticsExeter/cdegUtilities", quiet=TRUE)
@@ -96,7 +95,4 @@ if(all(all_pkgs %in% rownames(installed.packages()))){
   absent <- all_pkgs[all_pkgs %ni% rownames(installed.packages())]
   print(paste("Failed installation of", length(absent), "packages:", absent))
 }
-
-
-
 

--- a/array/DNAm/preprocessing/installLibraries.r
+++ b/array/DNAm/preprocessing/installLibraries.r
@@ -28,11 +28,6 @@ if (!require("BiocManager", quietly = TRUE))
 #---------------------------------------------------------------------#
 # INSTALL BIGMELON
 #---------------------------------------------------------------------#	
-	
-#Bigmelon required for all scripts
-install.packages("remotes") # install remotes package to install from github
-remotes::install_github("schalkwyk/wateRmelon")
-remotes::install_github("tjgorrie/bigmelon")
 
 #GDS script
 
@@ -78,8 +73,11 @@ install.packages(setdiff(pkgs_pred, rownames(installed.packages())),repos = "htt
 
 # load devtools to install from GitHub
 library(devtools)
+install.packages("remotes") # install remotes package to install from github
 install_github("ds420/CETYGO", quiet=TRUE)
 install_github("EpigeneticsExeter/cdegUtilities", quiet=TRUE)
+remotes::install_github("schalkwyk/wateRmelon")
+remotes::install_github("tjgorrie/bigmelon")
 
 
 ## Check all packages installed successfully ##


### PR DESCRIPTION
# Description

This pull request will move the package installation of bigmelon and wateRmelon to the end of the installLibraries.r script. This will make them more likely to be installed as the Bioconductor dependencies required for them (for example, minfi) will be installed by this point.

## Issue ticket number

This pull request is to address issue: #240.

## Type of pull request

- [x] Bug fix
- [ ] New feature/enhancement
- [ ] Code refactor
- [ ] Documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my code to check that it is functional
- [ ] I have used linters to check for common sources of errors
- [ ] I have implemented fail safes in my code to account for edge cases
- [ ] I have made the corresponding changes to the documentation
