### PR TITLE
feat: add gridExtra to packages to installation script

### DIFF
--- a/array/DNAm/preprocessing/installLibraries.r
+++ b/array/DNAm/preprocessing/installLibraries.r
@@ -68,7 +68,7 @@ install.packages(setdiff(pkgs_rep, rownames(installed.packages())),repos = "http
 
 #Additional packages for Brain Cell Proportion Prediction
 BiocManager::install(c("genefilter", "minfi"))
-pkgs_pred <- c("quadprog", "reshape2")
+pkgs_pred <- c("quadprog", "reshape2", "gridExtra")
 install.packages(setdiff(pkgs_pred, rownames(installed.packages())),repos = "https://cran.r-project.org")
 
 install.packages("remotes") # install remotes package to install from github


### PR DESCRIPTION
## Check

Please be happy with my positioning of the package in the packages lists. `gridExtra` is currently being used only in the CETYGO deconvolution script, so I put the package into `pkgs_pred` as a result.

## Issue ticket number

This pull request is to address issue: #244.

## Type of pull request

- [x] Bug fix
- [ ] New feature/enhancement
- [ ] Code refactor
- [ ] Documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my code to check that it is functional
- [ ] I have used linters to check for common sources of errors
- [ ] I have implemented fail safes in my code to account for edge cases
- [ ] I have made the corresponding changes to the documentation
