### PR TITLE
fix: use levels over unique

### DIFF
--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -98,7 +98,7 @@ is_wanted_column <- function(column_name, QCmetrics) {
 
   return(!(
     all(is.na(column)) ||
-    length(unique(column)) == 1L ||
+    length(levels(column)) == 1L ||
     anyDuplicated(column) == 0L
   ))
 }
@@ -122,7 +122,7 @@ define_plot_parameters <- function(QCmetrics, projVar) {
 
   for (column_name in plot_columns) {
     column <- parse_column(column_name, QCmetrics)
-    unique_variables <- length(unique(column))
+    unique_variables <- length(levels(column))
     colours <- rainbow(unique_variables)[column]
 
     legendParams[[column_name]] <- cbind(
@@ -180,7 +180,7 @@ send_removal_message <- function(column_name, QCmetrics) {
     removal_message(column_name, "all values were labelled as missing")
     return()
   }
-  if (length(unique(column)) == 1L) {
+  if (length(levels(column)) == 1L) {
     removal_message(column_name, "all values were equivalent")
     return()
   }


### PR DESCRIPTION
# Description
As decided in team meeting. We need to stick with one to avoid errors in the plotting section. If the user wants to plot NA values still, they can manually change their samplesheet so that the value is no longer blank (C for controls for example).

## Issue ticket number

This pull request is to address issue: #246 .

## Type of pull request

- [x] Bug fix
- [ ] New feature/enhancement
- [ ] Code refactor
- [ ] Documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my code to check that it is functional
- [ ] I have used linters to check for common sources of errors
- [ ] I have implemented fail safes in my code to account for edge cases
- [ ] I have made the corresponding changes to the documentation
