### PR TITLE
fix: 450k consistency

### DIFF
--- a/array/DNAm/preprocessing/calcQCMetrics.r
+++ b/array/DNAm/preprocessing/calcQCMetrics.r
@@ -85,12 +85,12 @@ if(arrayType == "V2"){
 	print("loaded EpicV2 manifest")
 }
 
-if(arrayType == "HM450K"){
+if(arrayType == "450K"){
 	load(file.path(refDir, "450K_reference/AllProbeIlluminaAnno.Rdata"))
 	manifest<-probeAnnot[match(fData(gfile)$Probe_ID, probeAnnot$ILMNID), c("CHR", "INFINIUM_DESIGN_TYPE")]
 	colnames(manifest) <- c("CHR", "Infinium_Design_Type")
 	manifest$CHR <- paste0("chr", manifest$CHR)
-	print("loaded hm450k manifest")
+	print("loaded 450k manifest")
 	rm(probeAnnot)
 }
 
@@ -164,7 +164,7 @@ if(!"PC1_cp" %in% colnames(QCmetrics)){
 if(!"PC1_betas" %in% colnames(QCmetrics)){
 	print("Calculating PCs of autosomal beta values")
 	# filter to autosomal only
-	if(arrayType == "V2" | arrayType == "HM450K"){
+	if(arrayType == "V2" | arrayType == "450K"){
 		auto.probes<-which(manifest$CHR != "chrX" & manifest$CHR != "chrY")
 	} else {
 		auto.probes<-which(fData(gfile)$chr != "chrX" & fData(gfile)$chr != "chrY")
@@ -303,7 +303,7 @@ if(!"nNAsPer" %in% colnames(QCmetrics)){
 # NOTE threshold for M prediction not valid for epicV2 data
 if(!"predSex" %in% colnames(QCmetrics)){	
 	print("Performing sex prediction from sex chromosome profiles")	
-	if(arrayType == "V2" | arrayType == "HM450K"){
+	if(arrayType == "V2" | arrayType == "450K"){
 		x.probes<-which(manifest$CHR == "chrX")
 		y.probes<-which(manifest$CHR == "chrY")
 	} else {

--- a/array/DNAm/preprocessing/checkRconfigFile.r
+++ b/array/DNAm/preprocessing/checkRconfigFile.r
@@ -75,9 +75,9 @@ if (!toupper(tissueType) %in% c("BRAIN", "BLOOD")) {
   bad_parameter_exists <- TRUE
   warning("\nUnrecognised tissueType. Must be either 'blood' or 'brain'\n")
 }
-if (!toupper(arrayType) %in% c("HM450K", "V1", "V2")) {
+if (!toupper(arrayType) %in% c("450K", "V1", "V2")) {
   bad_parameter_exists <- TRUE
-  warning("\nUnrecognised arrayType. Must be 'HM450K', 'V1' or 'V2'\n")
+  warning("\nUnrecognised arrayType. Must be '450K', 'V1' or 'V2'\n")
 }
 
 if (!"Cell_Type" %in% projVar && ctCheck) {

--- a/array/DNAm/preprocessing/clusterCellTypes.r
+++ b/array/DNAm/preprocessing/clusterCellTypes.r
@@ -61,12 +61,12 @@ manifest<-manifest[match(fData(gfile)$Probe_ID, manifest$IlmnID), c("CHR", "Infi
 print("loaded EpicV2 manifest")
 }
 
-if(arrayType == "HM450K"){
+if(arrayType == "450K"){
 load(file.path(refDir, "450K_reference/AllProbeIlluminaAnno.Rdata"))
 manifest<-probeAnnot[match(fData(gfile)$Probe_ID, probeAnnot$ILMNID), c("CHR", "INFINIUM_DESIGN_TYPE")]
 colnames(manifest) <- c("CHR", "Infinium_Design_Type")
 manifest$CHR <- paste0("chr", manifest$CHR)
-print("loaded hm450k manifest")
+print("loaded 450k manifest")
 rm(probeAnnot)
 }
 
@@ -80,7 +80,7 @@ QCmetrics<-QCmetrics[match(passQC, QCmetrics$Basename),]
 
 rawbetas<-gfile[,, node = "betas"]
 rawbetas<-rawbetas[,match(passQC, colnames(rawbetas))]
-if(arrayType == "V2" | arrayType == "HM450K"){
+if(arrayType == "V2" | arrayType == "450K"){
     auto.probes<-which(manifest$CHR != "chrX" & manifest$CHR != "chrY")
   } else {
     auto.probes<-which(fData(gfile)$chr != "chrX" & fData(gfile)$chr != "chrY")

--- a/array/DNAm/preprocessing/filterToAutosomes.r
+++ b/array/DNAm/preprocessing/filterToAutosomes.r
@@ -75,12 +75,12 @@ manifest<-manifest[match(fData(normfile)$Probe_ID, manifest$IlmnID), c("CHR", "I
 print("loaded EpicV2 manifest")
 }
 
-if(arrayType == "HM450K"){
+if(arrayType == "450K"){
 load(file.path(refDir, "450K_reference/AllProbeIlluminaAnno.Rdata"))
 manifest<-probeAnnot[match(fData(normfile)$Probe_ID, probeAnnot$ILMNID), c("CHR", "INFINIUM_DESIGN_TYPE")]
 colnames(manifest) <- c("CHR", "Infinium_Design_Type")
 manifest$CHR <- paste0("chr", manifest$CHR)
-print("loaded hm450k manifest")
+print("loaded 450k manifest")
 rm(probeAnnot)
 }
 
@@ -89,7 +89,7 @@ rm(probeAnnot)
 # FILTER TO AUTOSOMAL PROBES ONLY
 #----------------------------------------------------------------------#
 
-if(arrayType == "V2" | arrayType == "HM450K"){
+if(arrayType == "V2" | arrayType == "450K"){
     auto.probes<-which(manifest$CHR != "chrX" & manifest$CHR != "chrY")
 } else {
     auto.probes<-which(fData(normfile)$chr != "chrX" & fData(normfile)$chr != "chrY")

--- a/array/DNAm/preprocessing/loadDataGDS.r
+++ b/array/DNAm/preprocessing/loadDataGDS.r
@@ -143,7 +143,7 @@ for(i in 1:length(loadGroups)){
   ## update feature data
   if(updateProbes){
     print("Updating Feature data")
-    if(arrayType== "hm450k"){
+    if(arrayType== "450k"){
       annoObj <- minfi::getAnnotationObject("IlluminaHumanMethylation450kanno.ilmn12.hg19")
     }
     if(arrayType == "V1"){

--- a/array/DNAm/preprocessing/normalisation.r
+++ b/array/DNAm/preprocessing/normalisation.r
@@ -89,11 +89,11 @@ unmeth<-unmethylated(normfile)[,]
 rawbetas<-betas(normfile)[,]
 
 # need to know which probe type
-if(arrayType == "HM450K"){
+if(arrayType == "450K"){
 	load(file.path(refDir, "450K_reference/AllProbeIlluminaAnno.Rdata"))
 	probeAnnot<-probeAnnot[match(rownames(rawbetas), probeAnnot$TargetID),]
 	colnames(probeAnnot)[which(colnames(probeAnnot) == "INFINIUM_DESIGN_TYPE")]<-"designType"
-	print("loaded hm450k manifest")
+	print("loaded 450k manifest")
 } 
 
 if(arrayType == "V1"){

--- a/array/DNAm/preprocessing/rmarkdownChild/ctCheck.rmd
+++ b/array/DNAm/preprocessing/rmarkdownChild/ctCheck.rmd
@@ -22,12 +22,12 @@ if(arrayType == "V1"){
 	print("loaded EpicV1 manifest")
 }
 
-if(arrayType == "HM450K"){
+if(arrayType == "450K"){
   load(file.path(refDir, "450K_reference/AllProbeIlluminaAnno.Rdata"))
   manifest<-probeAnnot[match(fData(gfile)$Probe_ID, probeAnnot$ILMNID), c("CHR", "INFINIUM_DESIGN_TYPE")]
   colnames(manifest) <- c("CHR", "Infinium_Design_Type")
   manifest$CHR <- paste0("chr", manifest$CHR)
-  print("loaded hm450k manifest")
+  print("loaded 450k manifest")
   rm(probeAnnot)
 }
 
@@ -53,7 +53,7 @@ colnames(ctCounts)<-c("Profiled", "PassQCStage1")
 
 rawbetas<-gfile[,, node = "betas"]
 rawbetas<-rawbetas[,match(passQC, colnames(rawbetas))]
-if(arrayType == "V2" | arrayType == "HM450K"){
+if(arrayType == "V2" | arrayType == "450K"){
     auto.probes<-which(manifest$CHR != "chrX" & manifest$CHR != "chrY")
   } else {
     auto.probes<-which(fData(gfile)$chr != "chrX" & fData(gfile)$chr != "chrY")


### PR DESCRIPTION
# Description

This pull request will commit to using one of `450k` or `hm450k` or `HM450k` when looking at the value of `arrayType` from the config file. The inconsistency in the value sought causes manifest files to not load in certain scripts.

## Issue ticket number

This pull request is to address issue: #249.

## Type of pull request

- [x] Bug fix
- [ ] New feature/enhancement
- [ ] Code refactor
- [ ] Documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my code to check that it is functional
- [ ] I have used linters to check for common sources of errors
- [ ] I have implemented fail safes in my code to account for edge cases
- [ ] I have made the corresponding changes to the documentation
