### PR TITLE
fix: use 450K (capital) everywhere

### DIFF
--- a/array/DNAm/preprocessing/calcQCMetrics.r
+++ b/array/DNAm/preprocessing/calcQCMetrics.r
@@ -90,7 +90,7 @@ if(arrayType == "450K"){
 	manifest<-probeAnnot[match(fData(gfile)$Probe_ID, probeAnnot$ILMNID), c("CHR", "INFINIUM_DESIGN_TYPE")]
 	colnames(manifest) <- c("CHR", "Infinium_Design_Type")
 	manifest$CHR <- paste0("chr", manifest$CHR)
-	print("loaded 450k manifest")
+	print("loaded 450K manifest")
 	rm(probeAnnot)
 }
 

--- a/array/DNAm/preprocessing/clusterCellTypes.r
+++ b/array/DNAm/preprocessing/clusterCellTypes.r
@@ -66,7 +66,7 @@ load(file.path(refDir, "450K_reference/AllProbeIlluminaAnno.Rdata"))
 manifest<-probeAnnot[match(fData(gfile)$Probe_ID, probeAnnot$ILMNID), c("CHR", "INFINIUM_DESIGN_TYPE")]
 colnames(manifest) <- c("CHR", "Infinium_Design_Type")
 manifest$CHR <- paste0("chr", manifest$CHR)
-print("loaded 450k manifest")
+print("loaded 450K manifest")
 rm(probeAnnot)
 }
 

--- a/array/DNAm/preprocessing/filterToAutosomes.r
+++ b/array/DNAm/preprocessing/filterToAutosomes.r
@@ -80,7 +80,7 @@ load(file.path(refDir, "450K_reference/AllProbeIlluminaAnno.Rdata"))
 manifest<-probeAnnot[match(fData(normfile)$Probe_ID, probeAnnot$ILMNID), c("CHR", "INFINIUM_DESIGN_TYPE")]
 colnames(manifest) <- c("CHR", "Infinium_Design_Type")
 manifest$CHR <- paste0("chr", manifest$CHR)
-print("loaded 450k manifest")
+print("loaded 450K manifest")
 rm(probeAnnot)
 }
 

--- a/array/DNAm/preprocessing/loadDataGDS.r
+++ b/array/DNAm/preprocessing/loadDataGDS.r
@@ -143,7 +143,7 @@ for(i in 1:length(loadGroups)){
   ## update feature data
   if(updateProbes){
     print("Updating Feature data")
-    if(arrayType== "450k"){
+    if(arrayType== "450K"){
       annoObj <- minfi::getAnnotationObject("IlluminaHumanMethylation450kanno.ilmn12.hg19")
     }
     if(arrayType == "V1"){

--- a/array/DNAm/preprocessing/normalisation.r
+++ b/array/DNAm/preprocessing/normalisation.r
@@ -93,7 +93,7 @@ if(arrayType == "450K"){
 	load(file.path(refDir, "450K_reference/AllProbeIlluminaAnno.Rdata"))
 	probeAnnot<-probeAnnot[match(rownames(rawbetas), probeAnnot$TargetID),]
 	colnames(probeAnnot)[which(colnames(probeAnnot) == "INFINIUM_DESIGN_TYPE")]<-"designType"
-	print("loaded 450k manifest")
+	print("loaded 450K manifest")
 } 
 
 if(arrayType == "V1"){

--- a/array/DNAm/preprocessing/rmarkdownChild/ctCheck.rmd
+++ b/array/DNAm/preprocessing/rmarkdownChild/ctCheck.rmd
@@ -27,7 +27,7 @@ if(arrayType == "450K"){
   manifest<-probeAnnot[match(fData(gfile)$Probe_ID, probeAnnot$ILMNID), c("CHR", "INFINIUM_DESIGN_TYPE")]
   colnames(manifest) <- c("CHR", "Infinium_Design_Type")
   manifest$CHR <- paste0("chr", manifest$CHR)
-  print("loaded 450k manifest")
+  print("loaded 450K manifest")
   rm(probeAnnot)
 }
 


### PR DESCRIPTION
# Description

This pull request will enforce that 450K is used everywhere in the DNAm QC pipeline instead of sometimes using 450k. Considering that the Config checker ensures that the user inputs exactly 450K, this should now be fine.

## Issue ticket number

This pull request is to address issue: #249.

## Type of pull request

- [x] Bug fix
- [ ] New feature/enhancement
- [ ] Code refactor
- [ ] Documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my code to check that it is functional
- [ ] I have used linters to check for common sources of errors
- [ ] I have implemented fail safes in my code to account for edge cases
- [ ] I have made the corresponding changes to the documentation
