### PR TITLE
Try to fix issue 198 - if uniqueIDs is a character, convert to a data frame

### DIFF
--- a/array/DNAm/preprocessing/clusterCellTypes.r
+++ b/array/DNAm/preprocessing/clusterCellTypes.r
@@ -164,9 +164,9 @@ for(i in 1:nrow(QCmetrics)){
 keepCols<-c("Individual_ID", "Sex", "Age", "Phenotype", "Tissue.Centre") 
 keepCols<-keepCols[keepCols %in% colnames(QCmetrics)]
 uniqueIDs<-unique(QCmetrics[,keepCols]) 
-if (is.character(uniqueIDs)) {
+if (!is.data.frame(uniqueIDs)) {
     uniqueIDs <- data.frame(Individual_ID=uniqueIDs)
-} 
+}
 
 indFACSEff<-aggregate(maxSD[which(QCmetrics$Cell_Type != "Total")], by = 
 list(QCmetrics$Individual_ID[which(QCmetrics$Cell_Type != "Total")]), FUN = median, na.rm = 

--- a/array/DNAm/preprocessing/clusterCellTypes.r
+++ b/array/DNAm/preprocessing/clusterCellTypes.r
@@ -161,16 +161,19 @@ for(i in 1:nrow(QCmetrics)){
 #----------------------------------------------------------------------#
 # CALCULATE INDIVIDUAL FACS SCORE
 #----------------------------------------------------------------------#
-keepCols<-c("Individual_ID", "Sex", "Age", "Phenotype", "Tissue.Centre") 
+keepCols<-c("Individual_ID", "Sex", "Age", "Phenotype", "Tissue.Centre")
 keepCols<-keepCols[keepCols %in% colnames(QCmetrics)]
-uniqueIDs<-unique(QCmetrics[,keepCols]) 
+uniqueIDs<-unique(QCmetrics[,keepCols])
+
 if (!is.data.frame(uniqueIDs)) {
     uniqueIDs <- data.frame(Individual_ID=uniqueIDs)
 }
 
-indFACSEff<-aggregate(maxSD[which(QCmetrics$Cell_Type != "Total")], by = 
-list(QCmetrics$Individual_ID[which(QCmetrics$Cell_Type != "Total")]), FUN = median, na.rm = 
-TRUE)
+indFACSEff<-aggregate(
+	maxSD[which(QCmetrics$Cell_Type != "Total")],
+	by = list(QCmetrics$Individual_ID[which(QCmetrics$Cell_Type != "Total")]),
+	FUN = median,
+	na.rm = TRUE)
 nFACs<-table(QCmetrics$Individual_ID[QCmetrics$Cell_Type != "Total"])
 
 uniqueIDs$Individual_ID <- as.character(uniqueIDs$Individual_ID)

--- a/array/DNAm/preprocessing/clusterCellTypes.r
+++ b/array/DNAm/preprocessing/clusterCellTypes.r
@@ -161,10 +161,16 @@ for(i in 1:nrow(QCmetrics)){
 #----------------------------------------------------------------------#
 # CALCULATE INDIVIDUAL FACS SCORE
 #----------------------------------------------------------------------#
-keepCols<-c("Individual_ID", "Sex", "Age", "Phenotype", "Tissue.Centre")
+keepCols<-c("Individual_ID", "Sex", "Age", "Phenotype", "Tissue.Centre") 
 keepCols<-keepCols[keepCols %in% colnames(QCmetrics)]
-uniqueIDs<-unique(QCmetrics[,keepCols])
-indFACSEff<-indFACSEff<-aggregate(maxSD[which(QCmetrics$Cell_Type != "Total")], by = list(QCmetrics$Individual_ID[which(QCmetrics$Cell_Type != "Total")]), FUN = median, na.rm = TRUE)
+uniqueIDs<-unique(QCmetrics[,keepCols]) 
+if (is.character(uniqueIDs)) {
+    uniqueIDs <- data.frame(Individual_ID=uniqueIDs)
+} 
+
+indFACSEff<-aggregate(maxSD[which(QCmetrics$Cell_Type != "Total")], by = 
+list(QCmetrics$Individual_ID[which(QCmetrics$Cell_Type != "Total")]), FUN = median, na.rm = 
+TRUE)
 nFACs<-table(QCmetrics$Individual_ID[QCmetrics$Cell_Type != "Total"])
 
 uniqueIDs$Individual_ID <- as.character(uniqueIDs$Individual_ID)


### PR DESCRIPTION
# Description

In clusterCellTypes.r under 'Calculate individual FACS score' check if uniqueIDs is a character vector - if so convert it to a data frame. This stops uniqueIDs$Individual_ID <- as.character(uniqueIDs$Individual_ID) from breaking as $Individual_ID won't work on a character vector.

This pull request is to address issue: #198 

## Type of pull request

- [x] Bug fix
- [ ] New feature/enhancement
- [ ] Code refactor
- [ ] Documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code to check that it is functional
- [x] I have used linters to check for common sources of errors
- [x] I have implemented fail safes in my code to account for edge cases _(note: it only converts uniqueID$Individual_ID to a dataframe if uniqueID is a character, which would be caused by QCmetrics lacking the Age, Sex, Phenotype, and Tissue.Centre columns. The code also works if QCmetrics contains no columns whatsoever. **The code breaks if QCmetrics is a vector [edited] - as I haven't used BrainFANS can someone let me know if this would ever actually happen?)**_
- [ ] I have made the corresponding changes to the documentation
