### PR TITLE
refactor: use readManifest function from cdegUtilities

### DIFF
--- a/array/DNAm/preprocessing/calcQCMetrics.r
+++ b/array/DNAm/preprocessing/calcQCMetrics.r
@@ -27,8 +27,6 @@ gdsFile <-paste0(dataDir, "/2_gds/raw.gds")
 qcData <-paste0(dataDir, "/2_gds/QCmetrics/QCmetrics.rdata")
 genoFile <- paste0(dataDir, "/0_metadata/epicSNPs.raw")
 configFile <- paste0(dataDir, "/config.r")
-epic2Manifest <- paste0(refDir,"/EPICArray/EPIC-8v2-0_A1.csv")
-
 
 source(configFile)
 

--- a/array/DNAm/preprocessing/calcQCMetrics.r
+++ b/array/DNAm/preprocessing/calcQCMetrics.r
@@ -83,6 +83,8 @@ manifest <- cdegUtilities::readManifest(
 	probeMatchingIndex = fData(gfile)[["Probe_ID"]],
 	arrayType = arrayType 
 )
+if (!exists("manifest"))
+	stop("Manifest file could not be loaded correctly")
 
 
 

--- a/array/DNAm/preprocessing/calcQCMetrics.r
+++ b/array/DNAm/preprocessing/calcQCMetrics.r
@@ -78,21 +78,11 @@ if(file.exists(qcData)){
 	print("QC object initiated")
 }
 
-
-if(arrayType == "V2"){
-	manifest<-fread(epic2Manifest, skip=7, fill=TRUE, data.table=F)
-	manifest<-manifest[match(fData(gfile)$Probe_ID, manifest$IlmnID), c("CHR", "Infinium_Design_Type")]
-	print("loaded EpicV2 manifest")
-}
-
-if(arrayType == "450K"){
-	load(file.path(refDir, "450K_reference/AllProbeIlluminaAnno.Rdata"))
-	manifest<-probeAnnot[match(fData(gfile)$Probe_ID, probeAnnot$ILMNID), c("CHR", "INFINIUM_DESIGN_TYPE")]
-	colnames(manifest) <- c("CHR", "Infinium_Design_Type")
-	manifest$CHR <- paste0("chr", manifest$CHR)
-	print("loaded 450K manifest")
-	rm(probeAnnot)
-}
+manifest <- cdegUtilities::readManifest(
+	referenceDirectory = refDir,
+	probeMatchingIndex = fData(gfile)[["Probe_ID"]],
+	arrayType = arrayType 
+)
 
 
 
@@ -274,7 +264,7 @@ if(!"rmsd" %in% colnames(QCmetrics)){
 
 	if(arrayType == "V2"){
 		normbeta <- adjustedDasen(
-			onetwo = manifest$Infinium_Design_Type,
+			onetwo = manifest$designType,
 			chr = manifest$CHR,
 			mns = read.gdsn(methylated(gfile)),
 			uns = read.gdsn(unmethylated(gfile)))

--- a/array/DNAm/preprocessing/clusterCellTypes.r
+++ b/array/DNAm/preprocessing/clusterCellTypes.r
@@ -55,21 +55,11 @@ setwd(dataDir)
 
 gfile<-openfn.gds(gdsFile, readonly = FALSE)
 
-if(arrayType== "V2"){
-manifest<-fread(epic2Manifest, skip=7, fill=TRUE, data.table=F)
-manifest<-manifest[match(fData(gfile)$Probe_ID, manifest$IlmnID), c("CHR", "Infinium_Design_Type")]
-print("loaded EpicV2 manifest")
-}
-
-if(arrayType == "450K"){
-load(file.path(refDir, "450K_reference/AllProbeIlluminaAnno.Rdata"))
-manifest<-probeAnnot[match(fData(gfile)$Probe_ID, probeAnnot$ILMNID), c("CHR", "INFINIUM_DESIGN_TYPE")]
-colnames(manifest) <- c("CHR", "Infinium_Design_Type")
-manifest$CHR <- paste0("chr", manifest$CHR)
-print("loaded 450K manifest")
-rm(probeAnnot)
-}
-
+manifest <- cdegUtilities::readManifest(
+	referenceDirectory = refDir,
+	probeMatchingIndex = fData(gfile)[["Probe_ID"]],
+	arrayType = arrayType 
+)
 
 QCSum<-read.csv(paste0(dataDir, "/2_gds/QCmetrics/PassQCStatusAllSamples.csv"), row.names = 1, stringsAsFactors = FALSE)
 passQC<-QCSum$Basename[QCSum[,"passQCS2"]]

--- a/array/DNAm/preprocessing/clusterCellTypes.r
+++ b/array/DNAm/preprocessing/clusterCellTypes.r
@@ -26,7 +26,6 @@ qcOutFolder<-paste0(dataDir, "/2_gds/QCmetrics")
 qcData <-paste0(dataDir, "/2_gds/QCmetrics/QCmetrics.rdata")
 genoFile <- paste0(dataDir, "/0_metadata/epicSNPs.raw")
 configFile <- paste0(dataDir, "/config.r")
-epic2Manifest <- paste0(refDir,"/EPICArray/EPIC-8v2-0_A1.csv")
 
 source(configFile)
 

--- a/array/DNAm/preprocessing/clusterCellTypes.r
+++ b/array/DNAm/preprocessing/clusterCellTypes.r
@@ -60,6 +60,8 @@ manifest <- cdegUtilities::readManifest(
 	probeMatchingIndex = fData(gfile)[["Probe_ID"]],
 	arrayType = arrayType 
 )
+if (!exists("manifest"))
+	stop("Manifest file could not be loaded correctly")
 
 QCSum<-read.csv(paste0(dataDir, "/2_gds/QCmetrics/PassQCStatusAllSamples.csv"), row.names = 1, stringsAsFactors = FALSE)
 passQC<-QCSum$Basename[QCSum[,"passQCS2"]]

--- a/array/DNAm/preprocessing/normalisation.r
+++ b/array/DNAm/preprocessing/normalisation.r
@@ -93,6 +93,8 @@ manifest <- cdegUtilities::readManifest(
 	probeMatchingIndex = rownames(rawbetas),
 	arrayType = arrayType 
 )
+if (!exists("manifest"))
+	stop("Manifest file could not be loaded correctly")
 
 #----------------------------------------------------------------------#
 # NORMALISE ALL SAMPLES TOGETHER

--- a/array/DNAm/preprocessing/normalisation.r
+++ b/array/DNAm/preprocessing/normalisation.r
@@ -88,33 +88,17 @@ meth<-methylated(normfile)[,]
 unmeth<-unmethylated(normfile)[,]
 rawbetas<-betas(normfile)[,]
 
-# need to know which probe type
-if(arrayType == "450K"){
-	load(file.path(refDir, "450K_reference/AllProbeIlluminaAnno.Rdata"))
-	probeAnnot<-probeAnnot[match(rownames(rawbetas), probeAnnot$TargetID),]
-	colnames(probeAnnot)[which(colnames(probeAnnot) == "INFINIUM_DESIGN_TYPE")]<-"designType"
-	print("loaded 450K manifest")
-} 
-
-if(arrayType == "V1"){
-	probeAnnot<-read.table(file.path(refDir, "EPICArray/EPIC.anno.GRCh38.tsv"), sep = "\t", header = TRUE, stringsAsFactors = FALSE)
-	probeAnnot<-probeAnnot[match(rownames(rawbetas), probeAnnot$probeID),]
-	print("loaded EpicV1 manifest")
-}
-
-if(arrayType == "V2"){
-  probeAnnot<-fread(epic2Manifest, skip=7, fill=TRUE, data.table=F)
-  probeAnnot<-probeAnnot[match(rownames(rawbetas), probeAnnot$IlmnID), c("CHR", "Infinium_Design_Type")]
-  colnames(probeAnnot)[colnames(probeAnnot)=="Infinium_Design_Type"] <- "designType"
-  print("loaded EpicV2 manifest")
-}
-
+manifest <- cdegUtilities::readManifest(
+	referenceDirectory = refDir,
+	probeMatchingIndex = rownames(rawbetas),
+	arrayType = arrayType 
+)
 
 #----------------------------------------------------------------------#
 # NORMALISE ALL SAMPLES TOGETHER
 #----------------------------------------------------------------------#
 
-normbeta<-dasen(meth, unmeth, probeAnnot$designType)
+normbeta<-dasen(meth, unmeth, manifest$designType)
 add.gdsn(normfile, 'normbeta', val = normbeta, replace = TRUE)
 
 #----------------------------------------------------------------------#
@@ -129,7 +113,7 @@ if(length(cellTypes) > 1){
 	for(each in cellTypes){
 		index<-which(QCmetrics$Cell_Type == each)
 		if(length(index) > 2){
-			celltypeNormbeta[,index]<-dasen(meth[,index], unmeth[,index], probeAnnot$designType)
+			celltypeNormbeta[,index]<-dasen(meth[,index], unmeth[,index], manifest$designType)
 		}
 	}
 	add.gdsn(normfile, 'celltypenormbeta', val = celltypeNormbeta, replace = TRUE)

--- a/array/DNAm/preprocessing/normalisation.r
+++ b/array/DNAm/preprocessing/normalisation.r
@@ -25,7 +25,6 @@ normgdsFile<-sub("\\.gds", "Norm.gds", gdsFile)
 qcOutFolder<-file.path(dataDir, "/2_gds/QCmetrics")
 normData<-file.path(dataDir, "/3_normalised/normalised.rdata")
 configFile <- paste0(dataDir, "/config.r")
-epic2Manifest <- paste0(refDir,"/EPICArray/EPIC-8v2-0_A1.csv")
 
 source(configFile)
 

--- a/array/DNAm/preprocessing/rmarkdownChild/ctCheck.rmd
+++ b/array/DNAm/preprocessing/rmarkdownChild/ctCheck.rmd
@@ -11,6 +11,8 @@ manifest <- cdegUtilities::readManifest(
 	probeMatchingIndex = fData(gfile)[["Probe_ID"]],
 	arrayType = arrayType 
 )
+if (!exists("manifest"))
+	stop("Manifest file could not be loaded correctly")
 
 ## filter samples
 QCmetrics<-read.csv(paste0(qcOutFolder,"/QCMetricsPostCellTypeClustering.csv"), stringsAsFactors = FALSE)

--- a/array/DNAm/preprocessing/rmarkdownChild/ctCheck.rmd
+++ b/array/DNAm/preprocessing/rmarkdownChild/ctCheck.rmd
@@ -6,30 +6,11 @@ qcOutFolder<-paste0(dataDir, "/2_gds/QCmetrics")
 
 gfile<-openfn.gds(gdsFile, readonly = FALSE)
 
-
-# load manifests
-if(arrayType == "V2"){
-  epic2Manifest <- paste0(refDir,"/EPICArray/EPIC-8v2-0_A1.csv")
-  manifest<-fread(epic2Manifest, skip=7, fill=TRUE, data.table=F)
-  manifest<-manifest[match(fData(gfile)$Probe_ID, manifest$IlmnID), c("CHR", "Infinium_Design_Type")]
-  print("loaded EpicV2 manifest")
-}
-# below needs checking
-if(arrayType == "V1"){
-	manifest<-read.table(file.path(refDir, "EPICArray/EPIC.anno.GRCh38.tsv"), sep = "\t", header = TRUE, stringsAsFactors = FALSE)
-	manifest<-manifest[match(fData(gfile)$Probe_ID, probeAnnot$probeID), c("CHR", "INFINIUM_DESIGN_TYPE")]
-	colnames(manifest) <- c("CHR", "Infinium_Design_Type")
-	print("loaded EpicV1 manifest")
-}
-
-if(arrayType == "450K"){
-  load(file.path(refDir, "450K_reference/AllProbeIlluminaAnno.Rdata"))
-  manifest<-probeAnnot[match(fData(gfile)$Probe_ID, probeAnnot$ILMNID), c("CHR", "INFINIUM_DESIGN_TYPE")]
-  colnames(manifest) <- c("CHR", "Infinium_Design_Type")
-  manifest$CHR <- paste0("chr", manifest$CHR)
-  print("loaded 450K manifest")
-  rm(probeAnnot)
-}
+manifest <- cdegUtilities::readManifest(
+	referenceDirectory = refDir,
+	probeMatchingIndex = fData(gfile)[["Probe_ID"]],
+	arrayType = arrayType 
+)
 
 ## filter samples
 QCmetrics<-read.csv(paste0(qcOutFolder,"/QCMetricsPostCellTypeClustering.csv"), stringsAsFactors = FALSE)


### PR DESCRIPTION
# Description

This pull request will refactor the repeated code across the QC pipeline that attempts to load and standardise the manifests for 450K, EPIC V1 and EPIC V2. Instead of repeating the same code and slightly changing it each time, I have moved the general functionality of these code blocks over to the [cdegUtilities R package](https://github.com/EpigeneticsExeter/cdegUtilities/blob/main/R/readManifest.r). 

The `readManifest` function requires a reference index (for the probe IDs) and a path to the directory containing the manifest files (and checks `arrayType` is valid). In return, the function spits out a standardised data frame that contains the predictable 'designType' column and the predictable 'CHR' column (that has values 'chrxyz').

There may be a possible conflict with #262 in the future as I changed a line that was in an `adjustedDasen` function call.

## Issue ticket number

This pull request is to address issue: #235 (also fixes #185).

## Type of pull request

- [ ] Bug fix
- [ ] New feature/enhancement
- [x] Code refactor
- [ ] Documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my code to check that it is functional
- [x] I have used linters to check for common sources of errors
- [x] I have implemented fail safes in my code to account for edge cases
- [ ] I have made the corresponding changes to the documentation
