### PR TITLE
Add scandate extraction option

### DIFF
--- a/array/DNAm/config/config.example.r
+++ b/array/DNAm/config/config.example.r
@@ -20,6 +20,7 @@ perMiss<-2
 sexCheck<-TRUE
 snpCheck<-TRUE
 ctCheck<-TRUE
+extractScanDate<-FALSE # Adds scan date to gds files
 
 
 ## ctCheck variables

--- a/array/DNAm/preprocessing/checkRconfigFile.r
+++ b/array/DNAm/preprocessing/checkRconfigFile.r
@@ -29,7 +29,7 @@ source(configFile)
 
 qcRmdParams <- c("projectTitle", "processedBy")
 qcthres <- c("thresBS", "intenThres", "nvThres", "perMiss")
-logicalParams <- c("sexCheck", "snpCheck", "ctCheck")
+logicalParams <- c("sexCheck", "snpCheck", "ctCheck", "extractScanDate")
 
 ungrouped <- c("tissueType", "arrayType", "projVar")
 

--- a/array/DNAm/preprocessing/loadDataGDS.r
+++ b/array/DNAm/preprocessing/loadDataGDS.r
@@ -76,8 +76,14 @@ nProbes <- sapply(paste0("1_raw/", sampleSheet$Basename, "_Red.idat"), readIDAT,
 if(length(nProbes)==0){
   stop("Error calculating number of probes from IDATs.")
 }
-scanDate <- unlist(sapply(paste0("1_raw/", sampleSheet$Basename, "_Red.idat"), getScanDate))
-sampleSheet <- cbind(sampleSheet, nProbes, scanDate)
+
+## Old feature, not strictly required for remainder of the pipeline
+if (extractScanDate) {
+  scanDate <- unlist(sapply(paste0("1_raw/", sampleSheet$Basename, "_Red.idat"), getScanDate))
+  sampleSheet <- cbind(sampleSheet, nProbes, scanDate)
+} else {
+  sampleSheet <- cbind(sampleSheet, nProbes)
+}
 
 ## load data separately
 loadGroups <- split(gsub("1_raw/|_Red.idat", "", names(nProbes)), as.factor(nProbes))


### PR DESCRIPTION
# Description

The `scanDate` object is not strictly required for the rest of the pipeline (never used and no crashes as a result of removing it). If IDATS are missing scan date, this previously crashed. As such an option (default: false) has been added to stop this code executing by default. The information of scandate is not easy to extract from IDAT files without non-trivial R code, so the code has not been entirely removed (as the information may still be useful to some).

## Issue ticket number

This pull request is to address issue: #272.

## Type of pull request

- [x] Bug fix
- [x] New feature/enhancement
- [ ] Code refactor
- [ ] Documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my code to check that it is functional
- [x] I have used linters to check for common sources of errors
- [x] I have implemented fail safes in my code to account for edge cases
- [ ] I have made the corresponding changes to the documentation
