### PR TITLE
Add error catching in event scan date doesn't exist in an IDAT

### DIFF
--- a/array/DNAm/preprocessing/loadDataGDS.r
+++ b/array/DNAm/preprocessing/loadDataGDS.r
@@ -80,9 +80,10 @@ sampleSheet <- cbind(sampleSheet, nProbes)
 
 tryCatch(
   expr= {
-    scanDate <- unlist(sapply(
+    scanDate <- unlist(vapply(
       paste0("1_raw/", sampleSheet[["Basename"]], "_Red.idat"),
-      getScanDate
+      getScanDate,
+      character(1)
     ))
     sampleSheet <- cbind(sampleSheet, scanDate)
   },

--- a/array/DNAm/preprocessing/loadDataGDS.r
+++ b/array/DNAm/preprocessing/loadDataGDS.r
@@ -79,7 +79,7 @@ if(length(nProbes)==0){
 sampleSheet <- cbind(sampleSheet, nProbes)
 
 tryCatch(
-  expr= {
+  expr = {
     scanDate <- unlist(vapply(
       paste0("1_raw/", sampleSheet[["Basename"]], "_Red.idat"),
       cdegUtilities::getScanDate,

--- a/array/DNAm/preprocessing/loadDataGDS.r
+++ b/array/DNAm/preprocessing/loadDataGDS.r
@@ -82,7 +82,7 @@ tryCatch(
   expr= {
     scanDate <- unlist(vapply(
       paste0("1_raw/", sampleSheet[["Basename"]], "_Red.idat"),
-      getScanDate,
+      cdegUtilities::getScanDate,
       character(1)
     ))
     sampleSheet <- cbind(sampleSheet, scanDate)

--- a/array/DNAm/preprocessing/loadDataGDS.r
+++ b/array/DNAm/preprocessing/loadDataGDS.r
@@ -76,8 +76,17 @@ nProbes <- sapply(paste0("1_raw/", sampleSheet$Basename, "_Red.idat"), readIDAT,
 if(length(nProbes)==0){
   stop("Error calculating number of probes from IDATs.")
 }
-scanDate <- unlist(sapply(paste0("1_raw/", sampleSheet$Basename, "_Red.idat"), getScanDate))
-sampleSheet <- cbind(sampleSheet, nProbes, scanDate)
+tryCatch(
+  expr= {
+    scanDate <- unlist(sapply(paste0("1_raw/", sampleSheet$Basename, "_Red.idat"), getScanDate))
+    sampleSheet <- cbind(sampleSheet, nProbes, scanDate)
+  },
+  error = function(e) {
+    print(e)
+    message("No scan date could be found in at least one IDAT file.")
+    sampleSheet <- cbind(sampleSheet, nProbes)
+  }
+)
 
 ## load data separately
 loadGroups <- split(gsub("1_raw/|_Red.idat", "", names(nProbes)), as.factor(nProbes))

--- a/array/DNAm/preprocessing/loadDataGDS.r
+++ b/array/DNAm/preprocessing/loadDataGDS.r
@@ -80,7 +80,10 @@ sampleSheet <- cbind(sampleSheet, nProbes)
 
 tryCatch(
   expr= {
-    scanDate <- unlist(sapply(paste0("1_raw/", sampleSheet$Basename, "_Red.idat"), getScanDate))
+    scanDate <- unlist(sapply(
+      paste0("1_raw/", sampleSheet[["Basename"]], "_Red.idat"),
+      getScanDate
+    ))
     sampleSheet <- cbind(sampleSheet, scanDate)
   },
   error = function(e) {

--- a/array/DNAm/preprocessing/loadDataGDS.r
+++ b/array/DNAm/preprocessing/loadDataGDS.r
@@ -76,15 +76,16 @@ nProbes <- sapply(paste0("1_raw/", sampleSheet$Basename, "_Red.idat"), readIDAT,
 if(length(nProbes)==0){
   stop("Error calculating number of probes from IDATs.")
 }
+sampleSheet <- cbind(sampleSheet, nProbes)
+
 tryCatch(
   expr= {
     scanDate <- unlist(sapply(paste0("1_raw/", sampleSheet$Basename, "_Red.idat"), getScanDate))
-    sampleSheet <- cbind(sampleSheet, nProbes, scanDate)
+    sampleSheet <- cbind(sampleSheet, scanDate)
   },
   error = function(e) {
     print(e)
     message("No scan date could be found in at least one IDAT file.")
-    sampleSheet <- cbind(sampleSheet, nProbes)
   }
 )
 


### PR DESCRIPTION
# Description

Scan date is not actually required from this point forward, but the information may still be useful to some users (and extracting this value requires non-trivial R code).

## Issue ticket number

This pull request is to address issue: #272.

## Type of pull request

- [x] Bug fix
- [ ] New feature/enhancement
- [ ] Code refactor
- [ ] Documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my code to check that it is functional
- [ ] I have used linters to check for common sources of errors
- [x] I have implemented fail safes in my code to account for edge cases
- [ ] I have made the corresponding changes to the documentation
