### PR TITLE
Use DT datatables for rendering tables in DNAm QC markdown report

### DIFF
--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -197,7 +197,7 @@ for(item in projVar){
   DT::datatable(
     as.data.frame(table(QCmetrics[, item])),
     caption = paste("Summary of samples categorised by", item),
-    col.names = c("Variable", "Number of Samples")
+    colnames = c("Variable", "Number of Samples")
   )
 }
 ```
@@ -545,14 +545,14 @@ We identified `r length(unique(predictedduplicates))` genetically unique individ
 
 
 ```{r,echo = FALSE, results = "asis"}
-DT::datatable(t(as.data.frame(table(table(predictedduplicates)))), row.names = c("Number of Samples", "Number of Individuals"))
+DT::datatable(t(as.data.frame(table(table(predictedduplicates)))), rownames = c("Number of Samples", "Number of Individuals"))
 
 ```
 
 We can compare this to the expected distribution of number of samples per individuals based on the sample sheet. 
 
 ```{r,echo = FALSE, results = "asis"}
-DT::datatable(t(as.data.frame(table(table(QCmetrics$Individual_ID)))), row.names = c("Number of Samples", "Number of Individuals"))
+DT::datatable(t(as.data.frame(table(table(QCmetrics$Individual_ID)))), rownames = c("Number of Samples", "Number of Individuals"))
 
 ```
 
@@ -944,7 +944,7 @@ Post QC we identified `r length(unique(predictedduplicates))` genetically unique
 
 
 ```{r,echo = FALSE, results = "asis"}
-DT::datatable(t(as.data.frame(table(table(predictedduplicates)))), row.names = c("Number of Samples", "Number of Individuals"))
+DT::datatable(t(as.data.frame(table(table(predictedduplicates)))), rownames = c("Number of Samples", "Number of Individuals"))
 
 ```
 

--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -161,6 +161,12 @@ Data was loaded for `r nrow(QCmetrics)` samples from `r length(unique(QCmetrics$
 
 These are only included if they are categorical. For this study the following project variables were included:
 
+```{r, echo=FALSE,include = FALSE}
+# You need this code to conduct the magic dependences attaching so that we
+# can create DT::datatables() in a loop. I hate pandoc.
+DT::datatable(matrix())
+```
+
 ```{r projVarSpecification, echo = FALSE, results = "asis", echo = FALSE}
 
 send_removal_message <- function(column_name, QCmetrics) {
@@ -189,7 +195,7 @@ for (column_name in projVar) send_removal_message(column_name, QCmetrics)
 
 projVar <- remove_unwanted_columns(projVar, QCmetrics)
 for(item in projVar){
-  DT::datatable(
+  cat(knitr::knit_print(DT::datatable(
     as.data.frame(table(QCmetrics[, item])),
     caption = paste("Summary of samples categorised by", item),
     colnames = c("Variable", "Number of Samples"),
@@ -197,7 +203,7 @@ for(item in projVar){
       dom = "Bfrtip",
       buttons = c("copy", "csv")
     )
-  )
+  )))
 }
 ```
 

--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -199,6 +199,7 @@ for(item in projVar){
     as.data.frame(table(QCmetrics[, item])),
     caption = paste("Summary of samples categorised by", item),
     colnames = c("Variable", "Number of Samples"),
+    rownames = FALSE,
     extensions = "Buttons", options = list(
       dom = "Bfrtip",
       buttons = c("copy", "csv")

--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -916,9 +916,13 @@ for(i in 1:ncol(QCSum.min)){
 colnames(xTab)<-colnames(QCSum.min)
 rownames(xTab)<-colnames(QCSum.min)
 
-kbl(xTab) %>%
-  kable_styling(bootstrap_options = c("striped", "hover"))
-
+DT::datatable(
+  xTab,
+  extensions = "Buttons", options = list(
+    dom = "Bfrtip",
+    buttons = c("copy", "csv")
+  )
+)
 ```
 
 ## Correlations between QC metrics

--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -50,11 +50,6 @@ nSamIP<-sum(QCmetrics$intensPASS)
 
 par(mar = c(4,4,1,1))
 
-# When in a loop, pander() calls do not render. This option always allows these
-# calls to be rendered in the resultant html file. No, wrapping pander() calls
-# in a print() function does not work (well, not how we want them to at least).
-panderOptions('knitr.auto.asis', FALSE)
-
 ```
 
 

--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -194,7 +194,7 @@ for (column_name in projVar) send_removal_message(column_name, QCmetrics)
 
 projVar <- remove_unwanted_columns(projVar, QCmetrics)
 for(item in projVar){
-  pander(
+  DT::datatable(
     as.data.frame(table(QCmetrics[, item])),
     caption = paste("Summary of samples categorised by", item),
     col.names = c("Variable", "Number of Samples")
@@ -545,14 +545,14 @@ We identified `r length(unique(predictedduplicates))` genetically unique individ
 
 
 ```{r,echo = FALSE, results = "asis"}
-pander(t(as.data.frame(table(table(predictedduplicates)))), row.names = c("Number of Samples", "Number of Individuals"))
+DT::datatable(t(as.data.frame(table(table(predictedduplicates)))), row.names = c("Number of Samples", "Number of Individuals"))
 
 ```
 
 We can compare this to the expected distribution of number of samples per individuals based on the sample sheet. 
 
 ```{r,echo = FALSE, results = "asis"}
-pander(t(as.data.frame(table(table(QCmetrics$Individual_ID)))), row.names = c("Number of Samples", "Number of Individuals"))
+DT::datatable(t(as.data.frame(table(table(QCmetrics$Individual_ID)))), row.names = c("Number of Samples", "Number of Individuals"))
 
 ```
 
@@ -855,7 +855,7 @@ points(QCmetrics$x.cp, QCmetrics$y.cp, col = as.factor(QCmetrics$Sex), pch = 16)
 We will compare the sex predictions from the X and Y chromosomes.
 
 ```{r tabSexpredictions, echo = FALSE}
-pander(table(QCmetrics$predSex.x, QCmetrics$predSex.y))
+DT::datatable(table(QCmetrics$predSex.x, QCmetrics$predSex.y))
 ``` 
 
 Perform sex check against phenotype reported sexes: `r sexCheck`. 
@@ -944,7 +944,7 @@ Post QC we identified `r length(unique(predictedduplicates))` genetically unique
 
 
 ```{r,echo = FALSE, results = "asis"}
-pander(t(as.data.frame(table(table(predictedduplicates)))), row.names = c("Number of Samples", "Number of Individuals"))
+DT::datatable(t(as.data.frame(table(table(predictedduplicates)))), row.names = c("Number of Samples", "Number of Individuals"))
 
 ```
 

--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -197,7 +197,11 @@ for(item in projVar){
   DT::datatable(
     as.data.frame(table(QCmetrics[, item])),
     caption = paste("Summary of samples categorised by", item),
-    colnames = c("Variable", "Number of Samples")
+    colnames = c("Variable", "Number of Samples"),
+    extensions = "Buttons", options = list(
+      dom = "Bfrtip",
+      buttons = c("copy", "csv")
+    )
   )
 }
 ```
@@ -545,14 +549,28 @@ We identified `r length(unique(predictedduplicates))` genetically unique individ
 
 
 ```{r,echo = FALSE, results = "asis"}
-DT::datatable(t(as.data.frame(table(table(predictedduplicates)))), rownames = c("Number of Samples", "Number of Individuals"))
+DT::datatable(
+  t(as.data.frame(table(table(predictedduplicates)))),
+  rownames = c("Number of Samples", "Number of Individuals"),
+  extensions = "Buttons", options = list(
+    dom = "Bfrtip",
+    buttons = c("copy", "csv")
+  )
+)
 
 ```
 
 We can compare this to the expected distribution of number of samples per individuals based on the sample sheet. 
 
 ```{r,echo = FALSE, results = "asis"}
-DT::datatable(t(as.data.frame(table(table(QCmetrics$Individual_ID)))), rownames = c("Number of Samples", "Number of Individuals"))
+DT::datatable(
+  t(as.data.frame(table(table(QCmetrics$Individual_ID)))),
+  rownames = c("Number of Samples", "Number of Individuals"),
+  extensions = "Buttons", options = list(
+    dom = "Bfrtip",
+    buttons = c("copy", "csv")
+  )
+)
 
 ```
 
@@ -855,7 +873,13 @@ points(QCmetrics$x.cp, QCmetrics$y.cp, col = as.factor(QCmetrics$Sex), pch = 16)
 We will compare the sex predictions from the X and Y chromosomes.
 
 ```{r tabSexpredictions, echo = FALSE}
-DT::datatable(table(QCmetrics$predSex.x, QCmetrics$predSex.y))
+DT::datatable(
+  table(QCmetrics$predSex.x, QCmetrics$predSex.y),
+  extensions = "Buttons", options = list(
+    dom = "Bfrtip",
+    buttons = c("copy", "csv")
+  )
+)
 ``` 
 
 Perform sex check against phenotype reported sexes: `r sexCheck`. 
@@ -944,7 +968,14 @@ Post QC we identified `r length(unique(predictedduplicates))` genetically unique
 
 
 ```{r,echo = FALSE, results = "asis"}
-DT::datatable(t(as.data.frame(table(table(predictedduplicates)))), rownames = c("Number of Samples", "Number of Individuals"))
+DT::datatable(
+  t(as.data.frame(table(table(predictedduplicates)))),
+  rownames = c("Number of Samples", "Number of Individuals"),
+  extensions = "Buttons", options = list(
+    dom = "Bfrtip",
+    buttons = c("copy", "csv")
+  )
+)
 
 ```
 

--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -163,7 +163,7 @@ These are only included if they are categorical. For this study the following pr
 
 ```{r, echo=FALSE,include = FALSE}
 # You need this code to conduct the magic dependences attaching so that we
-# can create DT::datatables() in a loop. I hate pandoc.
+# can create DT::datatables() in a loop.
 DT::datatable(matrix())
 ```
 


### PR DESCRIPTION
# Description

This pull request will, like the title suggests, use `datatables` from the `DT` package to render any tables that are in the DNAm QC rmarkdown report. The advantage of rendering tables this way is:
- Tables are now paginated
- Tables have a search feature
- Columns can be sorted (alphabetically or numerically)

There is an additional feature I have added here where a user has the option to save each table directly to a csv file with the click of a button (or just copy the data into the clipboard).

![image](https://github.com/user-attachments/assets/e350437f-a8da-4a0b-bf47-6c7ad1be8aea)

I have updated #248 to include the new `DT` package also.

## Question

With lines like:

```R
t(as.data.frame(table(table(QCmetrics$Individual_ID)))),
```

Do people think this is actually readable? It took me a good 20 minutes to figure out what this is actually doing.

Would anyone oppose to replacing this with something more verbose?

```R
# Better variables names can be chosen of course
id_counts <- table(QCmetrics$Individual_ID)
id_frequency_counts <- table(id_counts)
id_frequency_table <- t(as.data.frame(id_frequency_counts)
```

## Issue ticket number

This pull request is to address issue: #271.

## Type of pull request

- [ ] Bug fix
- [x] New feature/enhancement
- [ ] Code refactor
- [ ] Documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code to check that it is functional
- [x] I have used linters to check for common sources of errors
- [ ] I have implemented fail safes in my code to account for edge cases
- [ ] I have made the corresponding changes to the documentation
