### PR TITLE
fix: remove Sentrix_ID/Position if all values are the same

### DIFF
--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -109,7 +109,10 @@ remove_unwanted_columns <- function(columns, QCmetrics) {
 }
 
 define_plot_parameters <- function(QCmetrics, projVar) {
-  plot_columns <- c(remove_unwanted_columns(projVar, QCmetrics), "Sentrix_ID", "Sentrix_Position")
+  plot_columns <- c(
+    remove_unwanted_columns(projVar, QCmetrics),
+    remove_unwanted_columns(c("Sentrix_ID","Sentrix_Position"), QCmetrics)
+  )
 
   plotCols <- data.frame("Basename" = QCmetrics[["Basename"]])
                      
@@ -163,7 +166,7 @@ These are only included if they are categorical. For this study the following pr
 
 ```{r, echo=FALSE,include = FALSE}
 # You need this code to conduct the magic dependences attaching so that we
-# can create DT::datatables() in a loop.
+# can create DT::datatables() in a loop. I hate pandoc.
 DT::datatable(matrix())
 ```
 
@@ -192,6 +195,8 @@ send_removal_message <- function(column_name, QCmetrics) {
 }
 
 for (column_name in projVar) send_removal_message(column_name, QCmetrics)
+send_removal_message("Sentrix_ID", QCmetrics)
+send_removal_message("Sentrix_Position", QCmetrics)
 
 projVar <- remove_unwanted_columns(projVar, QCmetrics)
 for(item in projVar){


### PR DESCRIPTION
# Description

This fixes the case where the linear regression model fails due to all samples having the same Senrtix ID or same Sentrix Position.

In the event that all samples have a unique ID or unique Position, these variables will continue to be removed. An option in the future may be added that allows this case to be ignored. We remove such variables currently as resultant plots can have so many lines such that it is incredibly hard to interpret (especially when you have lots of samples)

## Issue ticket number

This pull request is to address issue: #288 .

## Type of pull request

- [x] Bug fix
- [ ] New feature/enhancement
- [ ] Code refactor
- [ ] Documentation update

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my code to check that it is functional
- [x] I have used linters to check for common sources of errors
- [ ] I have implemented fail safes in my code to account for edge cases
- [ ] I have made the corresponding changes to the documentation
