### PR TITLE
Correct intensity boxplot labelling

### DIFF
--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -121,7 +121,7 @@ define_plot_parameters <- function(QCmetrics, projVar) {
     colours <- rainbow(unique_variables)[column]
 
     legendParams[[column_name]] <- cbind(
-      levels(column),
+      unique(column[!is.na(column)]),
       rainbow(unique_variables)
     )
     plotCols[[column_name]] <- colours

--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -121,7 +121,7 @@ define_plot_parameters <- function(QCmetrics, projVar) {
     colours <- rainbow(unique_variables)[column]
 
     legendParams[[column_name]] <- cbind(
-      unique(column[!is.na(column)]),
+      levels(column),
       rainbow(unique_variables)
     )
     plotCols[[column_name]] <- colours

--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -279,11 +279,18 @@ hist(QCmetrics$intens.ratio, xlab = "Ratio of M:U intensities", breaks = 25, mai
 
 for(i in 2:ncol(plotCols)){
   if(length(unique(plotCols[!is.na(QCmetrics$intens.ratio),i])) > 1){
-  	model<-lm(QCmetrics$intens.ratio ~ plotCols[,i])
-  	anova(model)
-  	legendDat<-legendParams[[i-1]]
-  	boxplot(QCmetrics$intens.ratio ~ plotCols[,i], col = legendDat[,2], names = legendDat[,1], xlab = "", ylab = "Ratio M:U", main = paste("Split by ", colnames(plotCols)[i]))
-  	title(main = paste("ANOVA P =", signif(anova(model)[1,5], 3)), line = 0.5, adj = 1)
+    model<-lm(QCmetrics$intens.ratio ~ plotCols[,i])
+    anova(model)
+    legendDat<-legendParams[[i-1]]
+    boxplot(
+	    QCmetrics$intens.ratio ~ plotCols[,i],
+	    col = legendDat[,2],
+	    names = legendDat[,1],
+	    xlab = "",
+	    ylab = "Ratio M:U",
+	    main = paste("Split by ", colnames(plotCols)[i])
+    )
+    title(main = paste("ANOVA P =", signif(anova(model)[1,5], 3)), line = 0.5, adj = 1)
   }
 }
 


### PR DESCRIPTION
# Description

This pull request will correct the labelling of box plots in the DNAm QC pipeline. I'm 80% sure that the problem is that `levels()` (which is being used to create the `legendParams` object) returns values in alphabetical order (which is useful). However, it is highly unlikely that your sample sheet has each column under `projVar` in alphabetical order as well (*i.e* you see a control sample before any female samples before any male samples). For an example (that isn't particularly well explained) of why this ruins the ordering see https://github.com/ejh243/BrainFANS/issues/265#issuecomment-2671213677.

To fix this I use `unique` again (see #247), this time avoiding any `NaN` values that arise from missing data in the sample sheet. This should then ensure that the ordering is consistent between `plotCols` and `legendParams`.

## Small problem

The colours don't actually align between `legendParams` and `plotCols` as the `rainbow` function will assign colours alphabetically as well (so `plotCols` will have colours assigned alphabetically, but `legendParams` will have colours assigned as they crop up in the sample sheet). I don't think this is a problem however, as there is no legend on the box plots, so the colour order doesn't matter at all. What matters is that each box on the box plot has a different colour assigned to it (which will continue to hold true).

## Issue ticket number

This pull request is to address issue: #265.

## Type of pull request

- [x] Bug fix
- [ ] New feature/enhancement
- [ ] Code refactor
- [ ] Documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my code to check that it is functional
- [ ] I have used linters to check for common sources of errors
- [ ] I have implemented fail safes in my code to account for edge cases
- [ ] I have made the corresponding changes to the documentation
