### PR TITLE
Fix errors associated with ctCheck when one cell type passes QC

### DIFF
--- a/array/DNAm/preprocessing/clusterCellTypes.r
+++ b/array/DNAm/preprocessing/clusterCellTypes.r
@@ -265,6 +265,10 @@ closestLabelledCellType[satb2NegIndex[!closestCellTypePCA[satb2NegIndex] %in% ne
 QCmetrics<-cbind(QCmetrics, closestCellTypePCA, closestLabelledCellType)
 write.csv(QCmetrics[which(closestLabelledCellType == "FALSE"),], paste0(qcOutFolder, "/SamplesPredictedDiffCellTypePCAMahDist.csv"))
 
+if (ncol(mahDistPCA) > 1) {
+  message("WARNING: Only one cell type passed QC for this dataset.")
+}
+
 #----------------------------------------------------------------------#
 # COMPARE TO CELL TYPE POLYTOPE
 #----------------------------------------------------------------------#

--- a/array/DNAm/preprocessing/rmarkdownChild/ctCheck.rmd
+++ b/array/DNAm/preprocessing/rmarkdownChild/ctCheck.rmd
@@ -311,31 +311,34 @@ pheatmap(rawbetas[order(sigma, decreasing = TRUE)[1:500],index], annotation_col 
 
 ```
 
-
-```{r, echo = FALSE, fig.width = 15, fig.height = 15}
+```{r pair_setup, echo = FALSE}
 # Pairs plot will fail if only one cell type passes QC
-if (ncol(mahDistPCA) > 1) {
-  cat("Here we will look at the correlations between the Mahalanobis distances across samples. This might highlight where common misclassifications could occur.")
+run_pairs <- ncol(mahDistPCA) > 1
+```
 
-  panel.cor <- function(x, y){
-      usr <- par("usr"); on.exit(par(usr))
-      par(usr = c(0, 1, 0, 1))
-      r <- round(cor(x, y), digits=2)
-      txt <- paste0("R = ", r)
-      cex.cor <- 0.8/strwidth(txt)
-      text(0.5, 0.5, txt, cex = cex.cor * r)
-  }
-# Customize upper panel
-  upper.panel<-function(x, y){
-    points(x,y, pch = 16, col = cellCols[as.factor(QCmetrics$Cell_Type)])
-    abline(a = 0, b = 1)
-  }
-  pairs(
-    mahDistPCA, 
-    lower.panel = panel.cor,
-    upper.panel = upper.panel
-  )
+```{r, results = 'asis', echo = FALSE, eval = run_pairs}
+cat("Here we will look at the correlations between the Mahalanobis distances across samples. This might highlight where common misclassifications could occur.")
+```
+
+```{r, echo = FALSE, fig.width = 15, fig.height = 15, eval = run_pairs}
+panel.cor <- function(x, y){
+    usr <- par("usr"); on.exit(par(usr))
+    par(usr = c(0, 1, 0, 1))
+    r <- round(cor(x, y), digits=2)
+    txt <- paste0("R = ", r)
+    cex.cor <- 0.8/strwidth(txt)
+    text(0.5, 0.5, txt, cex = cex.cor * r)
 }
+# Customize upper panel
+upper.panel<-function(x, y){
+  points(x,y, pch = 16, col = cellCols[as.factor(QCmetrics$Cell_Type)])
+  abline(a = 0, b = 1)
+}
+pairs(
+  mahDistPCA, 
+  lower.panel = panel.cor,
+  upper.panel = upper.panel
+)
 ```
 
 

--- a/array/DNAm/preprocessing/rmarkdownChild/ctCheck.rmd
+++ b/array/DNAm/preprocessing/rmarkdownChild/ctCheck.rmd
@@ -311,28 +311,31 @@ pheatmap(rawbetas[order(sigma, decreasing = TRUE)[1:500],index], annotation_col 
 
 ```
 
-Here we will look at the correlations between the Mahalanobis distances across samples. This might highlight where common misclassifications could occur. 
 
 ```{r, echo = FALSE, fig.width = 15, fig.height = 15}
+# Pairs plot will fail if only one cell type passes QC
+if (ncol(mahDistPCA) > 1) {
+  cat("Here we will look at the correlations between the Mahalanobis distances across samples. This might highlight where common misclassifications could occur.")
 
-panel.cor <- function(x, y){
-    usr <- par("usr"); on.exit(par(usr))
-    par(usr = c(0, 1, 0, 1))
-    r <- round(cor(x, y), digits=2)
-    txt <- paste0("R = ", r)
-    cex.cor <- 0.8/strwidth(txt)
-    text(0.5, 0.5, txt, cex = cex.cor * r)
-}
+  panel.cor <- function(x, y){
+      usr <- par("usr"); on.exit(par(usr))
+      par(usr = c(0, 1, 0, 1))
+      r <- round(cor(x, y), digits=2)
+      txt <- paste0("R = ", r)
+      cex.cor <- 0.8/strwidth(txt)
+      text(0.5, 0.5, txt, cex = cex.cor * r)
+  }
 # Customize upper panel
-upper.panel<-function(x, y){
-  points(x,y, pch = 16, col = cellCols[as.factor(QCmetrics$Cell_Type)])
-  abline(a = 0, b = 1)
+  upper.panel<-function(x, y){
+    points(x,y, pch = 16, col = cellCols[as.factor(QCmetrics$Cell_Type)])
+    abline(a = 0, b = 1)
+  }
+  pairs(
+    mahDistPCA, 
+    lower.panel = panel.cor,
+    upper.panel = upper.panel
+  )
 }
-# Create the plots
-pairs(mahDistPCA, 
-      lower.panel = panel.cor,
-      upper.panel = upper.panel)
-
 ```
 
 


### PR DESCRIPTION
# Description

This pull request will fix the crash that occurs when the `pairs()` plotting function is called in `ctCheck.rmd` when only one cell type passes QC (requires >1 column in the matrix used). In the event that only one cell type passes QC, a message will be sent to the error file.

### Small problem

The method in which the program determines that only one cell type passes QC is not the best. It specifically is checking if `mahDistPCA` has only one column (as this is what breaks the `pairs()` function call). However, this isn't very readable as the test isn't testing the source of the problem (only one cell type), but a consequence of it (`mahDistPCA` only has one column). This should be refactored at some point, but I have no idea what is happening in these files.

## Issue ticket number

This pull request is to address issue: #290.

## Type of pull request

- [x] Bug fix
- [ ] New feature/enhancement
- [ ] Code refactor
- [ ] Documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my code to check that it is functional
- [ ] I have used linters to check for common sources of errors
- [x] I have implemented fail safes in my code to account for edge cases
- [ ] I have made the corresponding changes to the documentation
