### PR TITLE
Update cdeg utilities to latest version

### DIFF
--- a/array/DNAm/preprocessing/calcQCMetrics.r
+++ b/array/DNAm/preprocessing/calcQCMetrics.r
@@ -78,9 +78,8 @@ if(file.exists(qcData)){
 }
 
 manifest <- cdegUtilities::readManifest(
-	referenceDirectory = refDir,
-	probeMatchingIndex = fData(gfile)[["Probe_ID"]],
-	arrayType = arrayType 
+	manifestFilePath = manifestFilePath,
+	probeMatchingIndex = fData(gfile)[["Probe_ID"]]
 )
 if (!exists("manifest"))
 	stop("Manifest file could not be loaded correctly")

--- a/array/DNAm/preprocessing/clusterCellTypes.r
+++ b/array/DNAm/preprocessing/clusterCellTypes.r
@@ -55,9 +55,8 @@ setwd(dataDir)
 gfile<-openfn.gds(gdsFile, readonly = FALSE)
 
 manifest <- cdegUtilities::readManifest(
-	referenceDirectory = refDir,
-	probeMatchingIndex = fData(gfile)[["Probe_ID"]],
-	arrayType = arrayType 
+	manifestFilePath = manifestFilePath,
+	probeMatchingIndex = fData(gfile)[["Probe_ID"]]
 )
 if (!exists("manifest"))
 	stop("Manifest file could not be loaded correctly")

--- a/array/DNAm/preprocessing/normalisation.r
+++ b/array/DNAm/preprocessing/normalisation.r
@@ -89,9 +89,8 @@ unmeth<-unmethylated(normfile)[,]
 rawbetas<-betas(normfile)[,]
 
 manifest <- cdegUtilities::readManifest(
-	referenceDirectory = refDir,
-	probeMatchingIndex = rownames(rawbetas),
-	arrayType = arrayType 
+	manifestFilePath = manifestFilePath,
+	probeMatchingIndex = rownames(rawbetas)
 )
 if (!exists("manifest"))
 	stop("Manifest file could not be loaded correctly")

--- a/array/DNAm/preprocessing/renv.lock
+++ b/array/DNAm/preprocessing/renv.lock
@@ -1096,15 +1096,15 @@
     },
     "cdegUtilities": {
       "Package": "cdegUtilities",
-      "Version": "0.0.1",
+      "Version": "0.0.2",
       "Source": "GitHub",
       "RemoteType": "github",
       "RemoteHost": "api.github.com",
       "RemoteUsername": "EpigeneticsExeter",
       "RemoteRepo": "cdegUtilities",
       "RemoteRef": "main",
-      "RemoteSha": "da6304a0bb37dfb1c0b410aed65abcf39bd26db0",
-      "Hash": "d3304e697373e7973fbc94537a85f427"
+      "RemoteSha": "5f8fa27ab11db56cefca09337e1c5ce94405c259",
+      "Hash": "9efc4f0d44b349059d6609f8e33d3393"
     },
     "class": {
       "Package": "class",

--- a/array/DNAm/preprocessing/rmarkdownChild/ctCheck.rmd
+++ b/array/DNAm/preprocessing/rmarkdownChild/ctCheck.rmd
@@ -7,9 +7,8 @@ qcOutFolder<-paste0(dataDir, "/2_gds/QCmetrics")
 gfile<-openfn.gds(gdsFile, readonly = FALSE)
 
 manifest <- cdegUtilities::readManifest(
-	referenceDirectory = refDir,
-	probeMatchingIndex = fData(gfile)[["Probe_ID"]],
-	arrayType = arrayType 
+	manifestFilePath = manifestFilePath,
+	probeMatchingIndex = fData(gfile)[["Probe_ID"]]
 )
 if (!exists("manifest"))
 	stop("Manifest file could not be loaded correctly")

--- a/sequencing/ATACSeq/config/config.r
+++ b/sequencing/ATACSeq/config/config.r
@@ -25,6 +25,9 @@ qcDir<-paste0(alignedDir, "/QCOutput" )
 sampleSheet<-paste0(metaDir, "/sampleSheet.csv")
 analysisDir<-paste0(dir, "/6_analysis")
 
+## Specify the full path to the manfiest file for your data
+manifestFilePath<-""
+
 ## create colourblind friendly palette
 colorBlindGrey8   <- c("#009E73", "#CC79A7", "#D55E00", "#999999", 
                        "#F0E442", "#0072B2",  "#E69F00", "#56B4E9")


### PR DESCRIPTION
# Description

This pull request will use the latest version of cdegUtilities. Specifically, the `readManifest` function has changed so that it now takes the full path to the manifest file as the input. This change is breaking as it requires users to update their config file (the `.r` one) to include the path to the manifest file. This will be communicated properly when the next patch version of BrainFANS is released.

## Issue ticket number

This pull request is to address issue: #302.

## Type of pull request

- [ ] Bug fix
- [x] New feature/enhancement
- [ ] Code refactor
- [ ] Documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my code to check that it is functional
- [ ] I have used linters to check for common sources of errors
- [ ] I have implemented fail safes in my code to account for edge cases
- [ ] I have made the corresponding changes to the documentation
