### PR TITLE
feat: add normalisation violence metrics definitions

### DIFF
--- a/array/DNAm/preprocessing/QC.rmd
+++ b/array/DNAm/preprocessing/QC.rmd
@@ -954,6 +954,14 @@ corrplot(cor(QCmetrics[,colsToKeep], use = "p"))
 
 ```
 
+The correlation plot above contains four normalisation violence metrics 
+(assessing the degree of difference between normalised and raw betas):
+
+* rmsd: root mean squared (of) differences
+* sdd: standard deviation (of) differences
+* sadd: standard absolute deviation (of) differences (|differences|)
+* srms: standardised root mean squared (rmsd/sdd)
+
 
 ## Reconfirm genetic relationships are correct
 


### PR DESCRIPTION
# Description

This pull request will add a list below the correlation matrix between QC metrics providing a quick explanation of the normalisation violence metrics (that come from `wateRmelon::qual`).

## Issue ticket number

This pull request is to address issue: #212.

## Type of pull request

- [ ] Bug fix
- [x] New feature/enhancement
- [ ] Code refactor
- [ ] Documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my code to check that it is functional
- [ ] I have used linters to check for common sources of errors
- [ ] I have implemented fail safes in my code to account for edge cases
- [ ] I have made the corresponding changes to the documentation
