### PR TITLE
Fix: ct check boolean column logic

### DIFF
--- a/array/DNAm/preprocessing/rmarkdownChild/ctCheck.rmd
+++ b/array/DNAm/preprocessing/rmarkdownChild/ctCheck.rmd
@@ -22,7 +22,7 @@ QCSum<-read.csv(paste0(dataDir, "/2_gds/QCmetrics/PassQCStatusAllSamples.csv"), 
 passQC<-QCSum$Basename[QCSum[,"passQCS2"]]
 
 nStart<-nrow(QCSum)
-nExclude<-sum(!QCSum[,"passQCS2"])
+nExclude<-sum(!QCSum[,"passQCS2"], na.rm=TRUE)
 
 nCTStart<-table(QCmetrics$Cell_Type)
 
@@ -265,7 +265,7 @@ for(each in badFACS){
 
 ```
 
-In total we identified, `r length(which(uniqueIDs$FACsEffiency >= 5))` individuals with sub optimal FACs sorting and all `r sum(!QCmetrics$passFACS & QCmetrics$Cell_Type != "Total")` samples for these individuals were excluded.
+In total we identified, `r length(which(uniqueIDs$FACsEffiency >= 5))` individuals with sub optimal FACs sorting and all `r sum(!QCmetrics$passFACS & QCmetrics$Cell_Type != "Total", na.rm=TRUE)` samples for these individuals were excluded.
 
 ```{r}
 
@@ -286,7 +286,7 @@ The exclusion of these individuals should give us more refined average profiles,
 ```{r, echo = FALSE}
 
 tab1<-table(QCmetrics$Cell_Type,QCmetrics$predLabelledCellType)
-percCon1<-sum(QCmetrics$predLabelledCellType)/nrow(QCmetrics)*100
+percCon1<-sum(QCmetrics$predLabelledCellType, na.rm=TRUE)/nrow(QCmetrics)*100
 
 ```
 
@@ -372,7 +372,7 @@ Given the overlap of different cell types, we define a regular polytope in 2 dim
 
 ```{r}
 tab2<-table(QCmetrics$Cell_Type, QCmetrics$withinSDMean)
-percCon2<-sum(QCmetrics$withinSDMean)/sum(QCmetrics$passFACS)*100
+percCon2<-sum(QCmetrics$withinSDMean, na.rm=TRUE)/sum(QCmetrics$passFACS, na.rm=TRUE)*100
 ```
 
 The table below shows how many samples were located within the same geometric space as the others in their sample group. In this sample, `r signif(percCon2, 3)`% of the samples had DNAm profiles which closely resembled the cell type they were labelled. 

--- a/array/DNAm/preprocessing/rmarkdownChild/ctCheck.rmd
+++ b/array/DNAm/preprocessing/rmarkdownChild/ctCheck.rmd
@@ -15,6 +15,14 @@ if (!exists("manifest"))
 
 ## filter samples
 QCmetrics<-read.csv(paste0(qcOutFolder,"/QCMetricsPostCellTypeClustering.csv"), stringsAsFactors = FALSE)
+is_potential_logical <- vapply(QCmetrics, function(x) {
+  if (!is.character(x)) return(FALSE)
+  cleaned <- na.omit(toupper(x))
+  all(cleaned %in% c("TRUE", "FALSE", "T", "F"))
+}, logical(1))
+
+QCmetrics[is_potential_logical] <- lapply(QCmetrics[is_potential_logical], 
+                                  function(x) as.logical(toupper(x)))
 load(paste0(dataDir,"/2_gds/QCmetrics/PCAAcrossAllCellTypes.rdata"))
 
 


### PR DESCRIPTION
# Description

This pull request will ensure Boolean logic centred around the "post cell type clustering" `QCmetrics` that is carried out in `ctCheck.rmd` functions as expected. The main problems were that the columns aren't guaranteed to be read as logical/Boolean columns if `NA` is ever present. On top of this, any `sum()` calls were not ignoring such `NA` values and so these wouldn't be outputting anything useful (just returning `NA` again).

## Issue ticket number

This pull request is to address issue: #316.

## Type of pull request

- [x] Bug fix
- [ ] New feature/enhancement
- [ ] Code refactor
- [ ] Documentation update

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have tested my code to check that it is functional
- [ ] I have used linters to check for common sources of errors
- [ ] I have implemented fail safes in my code to account for edge cases
- [ ] I have made the corresponding changes to the documentation
